### PR TITLE
IntegrationTest for ArtistsRestController replaced by UnitTest

### DIFF
--- a/src/main/java/rocks/metaldetector/web/controller/rest/ArtistsRestController.java
+++ b/src/main/java/rocks/metaldetector/web/controller/rest/ArtistsRestController.java
@@ -1,8 +1,7 @@
 package rocks.metaldetector.web.controller.rest;
 
 import lombok.AllArgsConstructor;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.web.PageableDefault;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -27,8 +26,9 @@ public class ArtistsRestController {
   @GetMapping(path = Endpoints.Rest.SEARCH,
               produces = {MediaType.APPLICATION_XML_VALUE, MediaType.APPLICATION_JSON_VALUE})
   public ResponseEntity<SearchResponse> handleNameSearch(@RequestParam(value = "query", defaultValue = "") String query,
-                                                         @PageableDefault Pageable pageable) {
-    Optional<SearchResponse> responseOptional = artistsService.searchDiscogsByName(query, pageable);
+                                                         @RequestParam(value = "page", defaultValue = "0") int page,
+                                                         @RequestParam(value = "size", defaultValue = "10") int size) {
+    Optional<SearchResponse> responseOptional = artistsService.searchDiscogsByName(query, PageRequest.of(page, size));
     return ResponseEntity.of(responseOptional);
   }
 

--- a/src/test/java/rocks/metaldetector/testutil/WithExceptionResolver.java
+++ b/src/test/java/rocks/metaldetector/testutil/WithExceptionResolver.java
@@ -1,0 +1,20 @@
+package rocks.metaldetector.testutil;
+
+import org.springframework.context.support.StaticApplicationContext;
+import org.springframework.web.accept.ContentNegotiationManager;
+import org.springframework.web.servlet.HandlerExceptionResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurationSupport;
+import rocks.metaldetector.model.exceptions.AppExceptionsHandler;
+
+public interface WithExceptionResolver {
+
+  default HandlerExceptionResolver exceptionResolver() {
+    StaticApplicationContext applicationContext = new StaticApplicationContext();
+    applicationContext.registerSingleton("exceptionHandler", AppExceptionsHandler.class);
+
+    WebMvcConfigurationSupport webMvcConfigurationSupport = new WebMvcConfigurationSupport();
+    webMvcConfigurationSupport.setApplicationContext(applicationContext);
+
+    return webMvcConfigurationSupport.handlerExceptionResolver(new ContentNegotiationManager());
+  }
+}

--- a/src/test/java/rocks/metaldetector/web/controller/rest/ArtistsRestControllerIT.java
+++ b/src/test/java/rocks/metaldetector/web/controller/rest/ArtistsRestControllerIT.java
@@ -1,7 +1,8 @@
 package rocks.metaldetector.web.controller.rest;
 
 import io.restassured.http.ContentType;
-import io.restassured.response.ValidatableResponse;
+import io.restassured.module.mockmvc.RestAssuredMockMvc;
+import io.restassured.module.mockmvc.response.ValidatableMockMvcResponse;
 import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -10,16 +11,19 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.context.support.StaticApplicationContext;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.accept.ContentNegotiationManager;
+import org.springframework.web.servlet.HandlerExceptionResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurationSupport;
 import rocks.metaldetector.config.constants.Endpoints;
+import rocks.metaldetector.model.exceptions.AppExceptionsHandler;
 import rocks.metaldetector.service.artist.ArtistsService;
-import rocks.metaldetector.testutil.WithIntegrationTestProfile;
-import rocks.metaldetector.web.RestAssuredRequestHandler;
+import rocks.metaldetector.web.RestAssuredMockMvcUtils;
 import rocks.metaldetector.web.dto.response.Pagination;
 import rocks.metaldetector.web.dto.response.SearchResponse;
 
@@ -31,23 +35,23 @@ import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 import static rocks.metaldetector.web.DtoFactory.ArtistNameSearchResponseFactory;
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ExtendWith(MockitoExtension.class)
-class ArtistsRestControllerIT implements WithAssertions, WithIntegrationTestProfile {
+class ArtistsRestControllerIT implements WithAssertions {
 
   private static final long VALID_ARTIST_ID = 252211L;
   private static final long INVALID_ARTIST_ID = 0L;
   private static final String VALID_SEARCH_REQUEST = "Darkthrone";
 
-  @MockBean
+  @Mock
   private ArtistsService artistsService;
 
-  @LocalServerPort
-  private int port;
+  @InjectMocks
+  private ArtistsRestController underTest;
 
-  private RestAssuredRequestHandler requestHandler;
+  private RestAssuredMockMvcUtils restAssuredUtils;
 
   @Nested
   @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -59,11 +63,12 @@ class ArtistsRestControllerIT implements WithAssertions, WithIntegrationTestProf
     private static final int DEFAULT_SIZE = 10;
     private static final int TOTAL_PAGES = 1;
 
-    private final String requestUri = "http://localhost:" + port + Endpoints.Rest.ARTISTS + Endpoints.Rest.SEARCH;
-
     @BeforeEach
     void setUp() {
-      requestHandler = new RestAssuredRequestHandler(requestUri);
+      restAssuredUtils = new RestAssuredMockMvcUtils(Endpoints.Rest.ARTISTS + Endpoints.Rest.SEARCH);
+      RestAssuredMockMvc.standaloneSetup(underTest,
+                                         springSecurity((request, response, chain) -> chain.doFilter(request, response)),
+                                         exceptionResolver());
     }
 
     @AfterEach
@@ -84,7 +89,7 @@ class ArtistsRestControllerIT implements WithAssertions, WithIntegrationTestProf
           .thenReturn(Optional.of(ArtistNameSearchResponseFactory.withOneResult()));
 
       // when
-      ValidatableResponse validatableResponse = requestHandler.doGet(ContentType.JSON, requestParams);
+      ValidatableMockMvcResponse validatableResponse = restAssuredUtils.doGet(requestParams);
 
       // then
       validatableResponse
@@ -116,7 +121,7 @@ class ArtistsRestControllerIT implements WithAssertions, WithIntegrationTestProf
           .thenReturn(Optional.empty());
 
       // when
-      ValidatableResponse validatableResponse = requestHandler.doGet(ContentType.JSON, requestParams);
+      ValidatableMockMvcResponse validatableResponse = restAssuredUtils.doGet(requestParams);
 
       // then
       validatableResponse.statusCode(HttpStatus.NOT_FOUND.value());
@@ -129,16 +134,16 @@ class ArtistsRestControllerIT implements WithAssertions, WithIntegrationTestProf
   @DisplayName("Test follow/unfollow endpoints")
   class FollowArtistTest {
 
-    private RestAssuredRequestHandler followRequestHandler;
-    private RestAssuredRequestHandler unfollowRequestHandler;
-
-    private final String followRequestUri   = "http://localhost:" + port + Endpoints.Rest.ARTISTS + Endpoints.Rest.FOLLOW;
-    private final String unfollowRequestUri = "http://localhost:" + port + Endpoints.Rest.ARTISTS + Endpoints.Rest.UNFOLLOW;
+    private RestAssuredMockMvcUtils followArtistRestAssuredUtils;
+    private RestAssuredMockMvcUtils unfollowArtistRestAssuredUtils;
 
     @BeforeEach
     void setUp() {
-      followRequestHandler    = new RestAssuredRequestHandler(followRequestUri);
-      unfollowRequestHandler  = new RestAssuredRequestHandler(unfollowRequestUri);
+      followArtistRestAssuredUtils  = new RestAssuredMockMvcUtils(Endpoints.Rest.ARTISTS + Endpoints.Rest.FOLLOW);
+      unfollowArtistRestAssuredUtils  = new RestAssuredMockMvcUtils(Endpoints.Rest.ARTISTS + Endpoints.Rest.UNFOLLOW);
+      RestAssuredMockMvc.standaloneSetup(underTest,
+                                         springSecurity((request, response, chain) -> chain.doFilter(request, response)),
+                                         exceptionResolver());
     }
 
     @AfterEach
@@ -153,7 +158,7 @@ class ArtistsRestControllerIT implements WithAssertions, WithIntegrationTestProf
       when(artistsService.followArtist(VALID_ARTIST_ID)).thenReturn(true);
 
       // when
-      ValidatableResponse validatableResponse = followRequestHandler.doPost("/" + VALID_ARTIST_ID, ContentType.JSON);
+      ValidatableMockMvcResponse validatableResponse = followArtistRestAssuredUtils.doPost("/" + VALID_ARTIST_ID);
 
       // then
       validatableResponse.statusCode(HttpStatus.OK.value());
@@ -167,7 +172,7 @@ class ArtistsRestControllerIT implements WithAssertions, WithIntegrationTestProf
       when(artistsService.followArtist(INVALID_ARTIST_ID)).thenReturn(false);
 
       // when
-      ValidatableResponse validatableResponse = followRequestHandler.doPost("/" + INVALID_ARTIST_ID, ContentType.JSON);
+      ValidatableMockMvcResponse validatableResponse = followArtistRestAssuredUtils.doPost("/" + INVALID_ARTIST_ID);
 
       // then
       validatableResponse.statusCode(HttpStatus.NOT_FOUND.value());
@@ -181,7 +186,7 @@ class ArtistsRestControllerIT implements WithAssertions, WithIntegrationTestProf
       when(artistsService.unfollowArtist(VALID_ARTIST_ID)).thenReturn(true);
 
       // when
-      ValidatableResponse validatableResponse = unfollowRequestHandler.doPost("/" + VALID_ARTIST_ID, ContentType.JSON);
+      ValidatableMockMvcResponse validatableResponse = unfollowArtistRestAssuredUtils.doPost("/" + VALID_ARTIST_ID);
 
       // then
       validatableResponse.statusCode(HttpStatus.OK.value());
@@ -195,11 +200,21 @@ class ArtistsRestControllerIT implements WithAssertions, WithIntegrationTestProf
       when(artistsService.unfollowArtist(VALID_ARTIST_ID)).thenReturn(false);
 
       // when
-      ValidatableResponse validatableResponse = unfollowRequestHandler.doPost("/" + VALID_ARTIST_ID, ContentType.JSON);
+      ValidatableMockMvcResponse validatableResponse = unfollowArtistRestAssuredUtils.doPost("/" + VALID_ARTIST_ID);
 
       // then
       validatableResponse.statusCode(HttpStatus.NOT_FOUND.value());
       verify(artistsService, times(1)).unfollowArtist(VALID_ARTIST_ID);
     }
+  }
+
+  private HandlerExceptionResolver exceptionResolver() {
+    StaticApplicationContext applicationContext = new StaticApplicationContext();
+    applicationContext.registerSingleton("exceptionHandler", AppExceptionsHandler.class);
+
+    WebMvcConfigurationSupport webMvcConfigurationSupport = new WebMvcConfigurationSupport();
+    webMvcConfigurationSupport.setApplicationContext(applicationContext);
+
+    return webMvcConfigurationSupport.handlerExceptionResolver(new ContentNegotiationManager());
   }
 }

--- a/src/test/java/rocks/metaldetector/web/controller/rest/ArtistsRestControllerTest.java
+++ b/src/test/java/rocks/metaldetector/web/controller/rest/ArtistsRestControllerTest.java
@@ -14,15 +14,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.context.support.StaticApplicationContext;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.accept.ContentNegotiationManager;
-import org.springframework.web.servlet.HandlerExceptionResolver;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurationSupport;
 import rocks.metaldetector.config.constants.Endpoints;
-import rocks.metaldetector.model.exceptions.AppExceptionsHandler;
 import rocks.metaldetector.service.artist.ArtistsService;
+import rocks.metaldetector.testutil.WithExceptionResolver;
 import rocks.metaldetector.web.RestAssuredMockMvcUtils;
 import rocks.metaldetector.web.dto.response.Pagination;
 import rocks.metaldetector.web.dto.response.SearchResponse;
@@ -39,7 +35,7 @@ import static org.springframework.security.test.web.servlet.setup.SecurityMockMv
 import static rocks.metaldetector.web.DtoFactory.ArtistNameSearchResponseFactory;
 
 @ExtendWith(MockitoExtension.class)
-class ArtistsRestControllerIT implements WithAssertions {
+class ArtistsRestControllerTest implements WithAssertions, WithExceptionResolver {
 
   private static final long VALID_ARTIST_ID = 252211L;
   private static final long INVALID_ARTIST_ID = 0L;
@@ -206,15 +202,5 @@ class ArtistsRestControllerIT implements WithAssertions {
       validatableResponse.statusCode(HttpStatus.NOT_FOUND.value());
       verify(artistsService, times(1)).unfollowArtist(VALID_ARTIST_ID);
     }
-  }
-
-  private HandlerExceptionResolver exceptionResolver() {
-    StaticApplicationContext applicationContext = new StaticApplicationContext();
-    applicationContext.registerSingleton("exceptionHandler", AppExceptionsHandler.class);
-
-    WebMvcConfigurationSupport webMvcConfigurationSupport = new WebMvcConfigurationSupport();
-    webMvcConfigurationSupport.setApplicationContext(applicationContext);
-
-    return webMvcConfigurationSupport.handlerExceptionResolver(new ContentNegotiationManager());
   }
 }

--- a/src/test/java/rocks/metaldetector/web/controller/rest/UserRestControllerTest.java
+++ b/src/test/java/rocks/metaldetector/web/controller/rest/UserRestControllerTest.java
@@ -19,16 +19,12 @@ import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.modelmapper.ModelMapper;
-import org.springframework.context.support.StaticApplicationContext;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.accept.ContentNegotiationManager;
-import org.springframework.web.servlet.HandlerExceptionResolver;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurationSupport;
 import rocks.metaldetector.config.constants.Endpoints;
-import rocks.metaldetector.model.exceptions.AppExceptionsHandler;
 import rocks.metaldetector.model.exceptions.ResourceNotFoundException;
 import rocks.metaldetector.model.exceptions.UserAlreadyExistsException;
 import rocks.metaldetector.service.user.UserService;
+import rocks.metaldetector.testutil.WithExceptionResolver;
 import rocks.metaldetector.web.DtoFactory.RegisterUserRequestFactory;
 import rocks.metaldetector.web.DtoFactory.UserDtoFactory;
 import rocks.metaldetector.web.RestAssuredMockMvcUtils;
@@ -52,7 +48,7 @@ import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 
 @ExtendWith(MockitoExtension.class)
-class UserRestControllerTest implements WithAssertions {
+class UserRestControllerTest implements WithAssertions, WithExceptionResolver {
 
   private static final String USER_ID = "public-user-id";
 
@@ -329,15 +325,5 @@ class UserRestControllerTest implements WithAssertions {
           Arguments.of("", "role", false)
       );
     }
-  }
-
-  private HandlerExceptionResolver exceptionResolver() {
-    StaticApplicationContext applicationContext = new StaticApplicationContext();
-    applicationContext.registerSingleton("exceptionHandler", AppExceptionsHandler.class);
-
-    WebMvcConfigurationSupport webMvcConfigurationSupport = new WebMvcConfigurationSupport();
-    webMvcConfigurationSupport.setApplicationContext(applicationContext);
-
-    return webMvcConfigurationSupport.handlerExceptionResolver(new ContentNegotiationManager());
   }
 }


### PR DESCRIPTION
The integration test for the ArtistRestController is replaced by a unit test. The Pageable in the controller's handleSearch() method signature had to be replaced by the int values for page and size as Pageable couldn't be injected in the unit test.