### PR TITLE
Error handling on client for user updates

### DIFF
--- a/webapp/src/main/java/rocks/metaldetector/service/exceptions/AppExceptionsHandler.java
+++ b/webapp/src/main/java/rocks/metaldetector/service/exceptions/AppExceptionsHandler.java
@@ -37,6 +37,12 @@ public class AppExceptionsHandler {
     return new ResponseEntity<>(createErrorResponse(exception), new HttpHeaders(), HttpStatus.CONFLICT);
   }
 
+  @ExceptionHandler(value = IllegalArgumentException.class)
+  public ResponseEntity<ErrorResponse> handleIllegalArgumentException(IllegalArgumentException exception, WebRequest webRequest) {
+    log.warn(webRequest.getContextPath() + ": " + exception.getMessage());
+    return new ResponseEntity<>(createErrorResponse(exception), new HttpHeaders(), HttpStatus.CONFLICT);
+  }
+
   @ExceptionHandler(value = {ResourceNotFoundException.class})
   public ResponseEntity<ErrorResponse> handleNotFoundException(RuntimeException exception, WebRequest webRequest) {
     log.warn(webRequest.getContextPath() + ": " + exception.getMessage());

--- a/webapp/src/main/java/rocks/metaldetector/service/exceptions/AppExceptionsHandler.java
+++ b/webapp/src/main/java/rocks/metaldetector/service/exceptions/AppExceptionsHandler.java
@@ -25,14 +25,14 @@ import java.util.stream.Collectors;
 @Slf4j
 public class AppExceptionsHandler {
 
-  @ExceptionHandler({MethodArgumentNotValidException.class, IllegalUserException.class})
-  public ResponseEntity<ErrorResponse> handleValidationErrors(RuntimeException exception, WebRequest webRequest) {
+  @ExceptionHandler(value = MethodArgumentNotValidException.class)
+  public ResponseEntity<ErrorResponse> handleValidationErrors(MethodArgumentNotValidException exception, WebRequest webRequest) {
     log.warn(webRequest.getContextPath() + ": " + exception.getMessage());
     return new ResponseEntity<>(createErrorResponse(exception), new HttpHeaders(), HttpStatus.BAD_REQUEST);
   }
 
-  @ExceptionHandler(value = UserAlreadyExistsException.class)
-  public ResponseEntity<ErrorResponse> handleAlreadyExistsException(UserAlreadyExistsException exception, WebRequest webRequest) {
+  @ExceptionHandler({UserAlreadyExistsException.class, IllegalUserException.class})
+  public ResponseEntity<ErrorResponse> handleUserException(RuntimeException exception, WebRequest webRequest) {
     log.warn(webRequest.getContextPath() + ": " + exception.getMessage());
     return new ResponseEntity<>(createErrorResponse(exception), new HttpHeaders(), HttpStatus.CONFLICT);
   }

--- a/webapp/src/main/java/rocks/metaldetector/service/exceptions/AppExceptionsHandler.java
+++ b/webapp/src/main/java/rocks/metaldetector/service/exceptions/AppExceptionsHandler.java
@@ -25,20 +25,14 @@ import java.util.stream.Collectors;
 @Slf4j
 public class AppExceptionsHandler {
 
-  @ExceptionHandler(value = MethodArgumentNotValidException.class)
-  public ResponseEntity<ErrorResponse> handleValidationErrors(MethodArgumentNotValidException exception, WebRequest webRequest) {
+  @ExceptionHandler({MethodArgumentNotValidException.class, IllegalUserException.class})
+  public ResponseEntity<ErrorResponse> handleValidationErrors(RuntimeException exception, WebRequest webRequest) {
     log.warn(webRequest.getContextPath() + ": " + exception.getMessage());
     return new ResponseEntity<>(createErrorResponse(exception), new HttpHeaders(), HttpStatus.BAD_REQUEST);
   }
 
   @ExceptionHandler(value = UserAlreadyExistsException.class)
   public ResponseEntity<ErrorResponse> handleAlreadyExistsException(UserAlreadyExistsException exception, WebRequest webRequest) {
-    log.warn(webRequest.getContextPath() + ": " + exception.getMessage());
-    return new ResponseEntity<>(createErrorResponse(exception), new HttpHeaders(), HttpStatus.CONFLICT);
-  }
-
-  @ExceptionHandler(value = IllegalArgumentException.class)
-  public ResponseEntity<ErrorResponse> handleIllegalArgumentException(IllegalArgumentException exception, WebRequest webRequest) {
     log.warn(webRequest.getContextPath() + ": " + exception.getMessage());
     return new ResponseEntity<>(createErrorResponse(exception), new HttpHeaders(), HttpStatus.CONFLICT);
   }

--- a/webapp/src/main/java/rocks/metaldetector/service/exceptions/IllegalUserException.java
+++ b/webapp/src/main/java/rocks/metaldetector/service/exceptions/IllegalUserException.java
@@ -1,0 +1,20 @@
+package rocks.metaldetector.service.exceptions;
+
+import rocks.metaldetector.service.user.UserErrorMessages;
+
+public class IllegalUserException extends RuntimeException {
+
+  private static final long serialVersionUID = 1L;
+
+  private IllegalUserException(String message) {
+    super(message);
+  }
+
+  public static IllegalUserException createAdminCannotDisableHimselfException() {
+    return new IllegalUserException(UserErrorMessages.ADMINISTRATOR_CANNOT_DISABLE_HIMSELF.toDisplayString());
+  }
+
+  public static IllegalUserException createAdminCannotDiscardHisRoleException() {
+    return new IllegalUserException(UserErrorMessages.ADMINISTRATOR_DISCARD_ROLE.toDisplayString());
+  }
+}

--- a/webapp/src/main/java/rocks/metaldetector/service/user/UserServiceImpl.java
+++ b/webapp/src/main/java/rocks/metaldetector/service/user/UserServiceImpl.java
@@ -10,6 +10,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.comparator.BooleanComparator;
+import rocks.metaldetector.service.exceptions.IllegalUserException;
 import rocks.metaldetector.support.ResourceNotFoundException;
 import rocks.metaldetector.service.exceptions.TokenExpiredException;
 import rocks.metaldetector.service.exceptions.UserAlreadyExistsException;
@@ -96,9 +97,9 @@ public class UserServiceImpl implements UserService {
 
     if (publicId.equals(currentUserSupplier.get().getPublicId())) {
       if (!userDto.isEnabled())
-        throw new IllegalArgumentException(UserErrorMessages.ADMINISTRATOR_CANNOT_DISABLE_HIMSELF.toDisplayString());
+        throw IllegalUserException.createAdminCannotDisableHimselfException();
       if (userEntity.isAdministrator() && !UserRole.getRoleFromString(userDto.getRole()).contains(ROLE_ADMINISTRATOR))
-        throw new IllegalArgumentException(UserErrorMessages.ADMINISTRATOR_DISCARD_ROLE.toDisplayString());
+        throw IllegalUserException.createAdminCannotDiscardHisRoleException();
     }
 
     userEntity.setUserRoles(UserRole.getRoleFromString(userDto.getRole()));

--- a/webapp/src/main/resources/static/js/admin/users.js
+++ b/webapp/src/main/resources/static/js/admin/users.js
@@ -133,6 +133,9 @@ function onCreateError(errorResponse, validationAreaId) {
  */
 function onUpdateError(errorResponse, validationAreaId) {
     onError(errorResponse, validationAreaId);
+
+    $('#updateRole').val('Administrator');
+    $('#updateStatus').val('Enabled');
 }
 
 /**
@@ -197,18 +200,9 @@ function showUpdateUserForm() {
 }
 
 /**
- * Updates a certain user.
- */
-function updateUser () {
-    sendUpdateUserRequest();
-    resetUpdateUserForm();
-    $('#update-user-dialog').modal('hide');
-}
-
-/**
  * Sends the update request to the server.
  */
-function sendUpdateUserRequest() {
+function updateUser() {
     $.post({
         url: '/rest/v1/users',
         data: createUpdateUserRequest(),

--- a/webapp/src/test/java/rocks/metaldetector/service/user/UserServiceTest.java
+++ b/webapp/src/test/java/rocks/metaldetector/service/user/UserServiceTest.java
@@ -21,6 +21,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import rocks.metaldetector.service.exceptions.IllegalUserException;
 import rocks.metaldetector.support.ResourceNotFoundException;
 import rocks.metaldetector.service.exceptions.TokenExpiredException;
 import rocks.metaldetector.service.exceptions.UserAlreadyExistsException;
@@ -419,7 +420,7 @@ class UserServiceTest implements WithAssertions {
     Throwable throwable = catchThrowable(() -> userService.updateUser(PUBLIC_ID, userDtoForUpdate));
 
     // then
-    assertThat(throwable).isInstanceOf(IllegalArgumentException.class);
+    assertThat(throwable).isInstanceOf(IllegalUserException.class);
     assertThat(throwable).hasMessage(UserErrorMessages.ADMINISTRATOR_DISCARD_ROLE.toDisplayString());
   }
 
@@ -440,7 +441,7 @@ class UserServiceTest implements WithAssertions {
     Throwable throwable = catchThrowable(() -> userService.updateUser(PUBLIC_ID, userDtoForUpdate));
 
     // then
-    assertThat(throwable).isInstanceOf(IllegalArgumentException.class);
+    assertThat(throwable).isInstanceOf(IllegalUserException.class);
     assertThat(throwable).hasMessage(UserErrorMessages.ADMINISTRATOR_CANNOT_DISABLE_HIMSELF.toDisplayString());
   }
 


### PR DESCRIPTION
The error handling for failing user updates for the client is now working. The server answers with a bad request and the client shows the error message.