### PR TITLE
Increase jQuery version

### DIFF
--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -21,7 +21,7 @@
         <hibernate-validator.version>6.1.2.Final</hibernate-validator.version>
         <validation-api.version>2.0.1.Final</validation-api.version>
         <bootstrap.version>4.4.1-1</bootstrap.version>
-        <jquery.version>3.4.1</jquery.version>
+        <jquery.version>3.5.0</jquery.version>
         <popperJS.version>2.0.2</popperJS.version>
         <material-icons.version>0.3.1</material-icons.version>
         <rest-assured.version>4.2.0</rest-assured.version>


### PR DESCRIPTION
I looked at the generated detector jar once and there were two jquery jars in different versions. With the latest version there is no conflict anymore. Let's see if this fixes the problem. 