### PR TITLE
set mail from header

### DIFF
--- a/webapp/src/main/java/rocks/metaldetector/service/email/JavaMailEmailService.java
+++ b/webapp/src/main/java/rocks/metaldetector/service/email/JavaMailEmailService.java
@@ -64,6 +64,7 @@ public class JavaMailEmailService implements EmailService {
       helper.setTo(email.getRecipient());
       helper.setText(html, true);
       helper.setSubject(email.getSubject());
+      helper.setFrom(mailConfig.getFromEmail());
       helper.setReplyTo(mailConfig.getFromEmail());
     }
     catch (MessagingException me) {


### PR DESCRIPTION
Our e-mails are currently still blocked by GMail, for example, because we do not send the From header.