### PR TITLE
Protect login from brute force

### DIFF
--- a/persistence/src/main/java/rocks/metaldetector/persistence/domain/user/UserEntity.java
+++ b/persistence/src/main/java/rocks/metaldetector/persistence/domain/user/UserEntity.java
@@ -20,9 +20,7 @@ import javax.persistence.Enumerated;
 import javax.persistence.FetchType;
 import javax.persistence.PrePersist;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -70,10 +68,6 @@ public class UserEntity extends BaseEntity implements UserDetails {
   @Column(name = "last_login")
   private LocalDateTime lastLogin;
 
-  @Column(name = "failed_logins")
-  @ElementCollection(fetch = FetchType.EAGER)
-  private List<LocalDateTime> failedLogins;
-
   @Builder
   public UserEntity(@NonNull String username, @NonNull String email, @NonNull String password,
                     @NonNull Set<UserRole> userRoles, boolean enabled) {
@@ -82,7 +76,6 @@ public class UserEntity extends BaseEntity implements UserDetails {
     this.password = password;
     this.userRoles = userRoles;
     this.enabled = enabled;
-    this.failedLogins = new ArrayList<>();
   }
 
   public void setPublicId(String newPublicId) {
@@ -167,15 +160,4 @@ public class UserEntity extends BaseEntity implements UserDetails {
     this.lastLogin = lastLogin;
   }
 
-  public List<LocalDateTime> getFailedLogins() {
-    return List.copyOf(this.failedLogins);
-  }
-
-  public void addFailedLogin(LocalDateTime lastLogin) {
-    this.failedLogins.add(lastLogin);
-  }
-
-  public void clearFailedLogins() {
-    this.failedLogins.clear();
-  }
 }

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -21,7 +21,7 @@
         <hibernate-validator.version>6.1.2.Final</hibernate-validator.version>
         <validation-api.version>2.0.1.Final</validation-api.version>
         <bootstrap.version>4.4.1-1</bootstrap.version>
-        <jquery.version>3.4.1</jquery.version>
+        <jquery.version>3.5.0</jquery.version>
         <popperJS.version>2.0.2</popperJS.version>
         <material-icons.version>0.3.1</material-icons.version>
         <rest-assured.version>4.2.0</rest-assured.version>

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -152,4 +152,14 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <!-- Builds an executable JAR with all dependencies -->
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/webapp/src/main/java/rocks/metaldetector/config/logging/CacheLogger.java
+++ b/webapp/src/main/java/rocks/metaldetector/config/logging/CacheLogger.java
@@ -1,0 +1,15 @@
+package rocks.metaldetector.config.logging;
+
+import lombok.extern.slf4j.Slf4j;
+import org.ehcache.event.CacheEvent;
+import org.ehcache.event.CacheEventListener;
+
+@Slf4j
+public class CacheLogger implements CacheEventListener<String, Long> {
+
+  @Override
+  public void onEvent(CacheEvent<? extends String, ? extends Long> cacheEvent) {
+    log.info("Key: {} | EventType: {} | Old value: {} | New value: {}", cacheEvent.getKey(),
+             cacheEvent.getType(), cacheEvent.getOldValue(), cacheEvent.getNewValue());
+  }
+}

--- a/webapp/src/main/java/rocks/metaldetector/config/misc/CacheConfig.java
+++ b/webapp/src/main/java/rocks/metaldetector/config/misc/CacheConfig.java
@@ -1,9 +1,21 @@
 package rocks.metaldetector.config.misc;
 
+import lombok.AllArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.context.request.RequestContextListener;
 
 @Configuration
 @EnableCaching
+@AllArgsConstructor
 public class CacheConfig {
+
+  @Bean
+  @ConditionalOnMissingBean(RequestContextListener.class)
+  public RequestContextListener requestContextListener() {
+    return new RequestContextListener();
+  }
+
 }

--- a/webapp/src/main/java/rocks/metaldetector/config/misc/CacheConfig.java
+++ b/webapp/src/main/java/rocks/metaldetector/config/misc/CacheConfig.java
@@ -17,5 +17,4 @@ public class CacheConfig {
   public RequestContextListener requestContextListener() {
     return new RequestContextListener();
   }
-
 }

--- a/webapp/src/main/java/rocks/metaldetector/security/AuthenticationListener.java
+++ b/webapp/src/main/java/rocks/metaldetector/security/AuthenticationListener.java
@@ -1,27 +1,33 @@
 package rocks.metaldetector.security;
 
 import lombok.AllArgsConstructor;
+import org.apache.commons.codec.digest.DigestUtils;
 import org.springframework.context.event.EventListener;
 import org.springframework.security.authentication.event.AuthenticationFailureBadCredentialsEvent;
 import org.springframework.security.authentication.event.AuthenticationSuccessEvent;
 import org.springframework.security.web.authentication.WebAuthenticationDetails;
 import org.springframework.stereotype.Component;
+import rocks.metaldetector.service.user.UserService;
 
 @Component
 @AllArgsConstructor
 public class AuthenticationListener {
 
   private final LoginAttemptService loginAttemptService;
+  private final UserService userService;
+  private final CurrentUserSupplier currentUserSupplier;
 
   @EventListener
   public void onAuthenticationSuccess(AuthenticationSuccessEvent event) {
     WebAuthenticationDetails authenticationDetails = (WebAuthenticationDetails) event.getAuthentication().getDetails();
-    loginAttemptService.loginSucceeded(authenticationDetails.getRemoteAddress().hashCode());
+    loginAttemptService.loginSucceeded(DigestUtils.md5Hex(authenticationDetails.getRemoteAddress()));
+
+    userService.persistSuccessfulLogin(currentUserSupplier.get().getPublicId());
   }
 
   @EventListener
   public void onAuthenticationFailure(AuthenticationFailureBadCredentialsEvent event) {
     WebAuthenticationDetails authenticationDetails = (WebAuthenticationDetails) event.getAuthentication().getDetails();
-    loginAttemptService.loginFailed(authenticationDetails.getRemoteAddress().hashCode());
+    loginAttemptService.loginFailed(DigestUtils.md5Hex(authenticationDetails.getRemoteAddress()));
   }
 }

--- a/webapp/src/main/java/rocks/metaldetector/security/AuthenticationListener.java
+++ b/webapp/src/main/java/rocks/metaldetector/security/AuthenticationListener.java
@@ -7,6 +7,7 @@ import org.springframework.security.authentication.event.AuthenticationFailureBa
 import org.springframework.security.authentication.event.AuthenticationSuccessEvent;
 import org.springframework.security.web.authentication.WebAuthenticationDetails;
 import org.springframework.stereotype.Component;
+import rocks.metaldetector.persistence.domain.user.UserEntity;
 import rocks.metaldetector.service.user.UserService;
 
 @Component
@@ -15,14 +16,13 @@ public class AuthenticationListener {
 
   private final LoginAttemptService loginAttemptService;
   private final UserService userService;
-  private final CurrentUserSupplier currentUserSupplier;
 
   @EventListener
   public void onAuthenticationSuccess(AuthenticationSuccessEvent event) {
     WebAuthenticationDetails authenticationDetails = (WebAuthenticationDetails) event.getAuthentication().getDetails();
     loginAttemptService.loginSucceeded(DigestUtils.md5Hex(authenticationDetails.getRemoteAddress()));
 
-    userService.persistSuccessfulLogin(currentUserSupplier.get().getPublicId());
+    userService.persistSuccessfulLogin(((UserEntity) event.getAuthentication().getPrincipal()).getPublicId());
   }
 
   @EventListener

--- a/webapp/src/main/java/rocks/metaldetector/security/LoginAttemptService.java
+++ b/webapp/src/main/java/rocks/metaldetector/security/LoginAttemptService.java
@@ -15,7 +15,7 @@ public class LoginAttemptService {
 
   private final CacheManager cacheManager;
 
-  @CacheEvict(value = "failedLogins")
+  @CacheEvict(value = FAILED_LOGINS_CACHE)
   public void loginSucceeded(String ipHash) {
   }
 

--- a/webapp/src/main/java/rocks/metaldetector/security/LoginAttemptService.java
+++ b/webapp/src/main/java/rocks/metaldetector/security/LoginAttemptService.java
@@ -3,6 +3,7 @@ package rocks.metaldetector.security;
 import lombok.AllArgsConstructor;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -10,23 +11,31 @@ import org.springframework.stereotype.Service;
 public class LoginAttemptService {
 
   private static final int MAX_ATTEMPTS = 5;
-  private static final String FAILED_LOGINS_CACHE = "failedLogins";
+  public static final String FAILED_LOGINS_CACHE = "failedLogins";
 
   private final CacheManager cacheManager;
 
-  public void loginSucceeded(int ipHash) {
-    Cache cache = cacheManager.getCache(FAILED_LOGINS_CACHE);
-    cache.evictIfPresent(ipHash);
+  @CacheEvict(value = "failedLogins")
+  public void loginSucceeded(String ipHash) {
   }
 
-  public void loginFailed(int ipHash) {
+  public void loginFailed(String ipHash) {
     Cache cache = cacheManager.getCache(FAILED_LOGINS_CACHE);
-    long attempts = cache.get(ipHash) != null ? (Long) cache.get(ipHash).get() : 0;
-    cache.put(ipHash, ++attempts);
+
+    if (cache != null) {
+      Cache.ValueWrapper valueWrapper = cache.get(ipHash);
+      int attempts = valueWrapper != null ? (int) valueWrapper.get() : 0;
+      cache.put(ipHash, ++attempts);
+    }
   }
 
-  public boolean isBlocked(int ipHash) {
+  public boolean isBlocked(String ipHash) {
     Cache cache = cacheManager.getCache(FAILED_LOGINS_CACHE);
-    return cache.get(ipHash) != null && ((Long) cache.get(ipHash).get()) >= MAX_ATTEMPTS;
+
+    if (cache != null) {
+      Cache.ValueWrapper valueWrapper = cache.get(ipHash);
+      return valueWrapper != null && (int) valueWrapper.get() >= MAX_ATTEMPTS;
+    }
+    return true;
   }
 }

--- a/webapp/src/main/java/rocks/metaldetector/security/LoginAttemptService.java
+++ b/webapp/src/main/java/rocks/metaldetector/security/LoginAttemptService.java
@@ -1,0 +1,32 @@
+package rocks.metaldetector.security;
+
+import lombok.AllArgsConstructor;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.stereotype.Service;
+
+@Service
+@AllArgsConstructor
+public class LoginAttemptService {
+
+  private static final int MAX_ATTEMPTS = 5;
+  private static final String FAILED_LOGINS_CACHE = "failedLogins";
+
+  private final CacheManager cacheManager;
+
+  public void loginSucceeded(int ipHash) {
+    Cache cache = cacheManager.getCache(FAILED_LOGINS_CACHE);
+    cache.evictIfPresent(ipHash);
+  }
+
+  public void loginFailed(int ipHash) {
+    Cache cache = cacheManager.getCache(FAILED_LOGINS_CACHE);
+    long attempts = cache.get(ipHash) != null ? (Long) cache.get(ipHash).get() : 0;
+    cache.put(ipHash, ++attempts);
+  }
+
+  public boolean isBlocked(int ipHash) {
+    Cache cache = cacheManager.getCache(FAILED_LOGINS_CACHE);
+    return cache.get(ipHash) != null && ((Long) cache.get(ipHash).get()) >= MAX_ATTEMPTS;
+  }
+}

--- a/webapp/src/main/java/rocks/metaldetector/security/handler/CustomAuthenticationFailureHandler.java
+++ b/webapp/src/main/java/rocks/metaldetector/security/handler/CustomAuthenticationFailureHandler.java
@@ -1,6 +1,7 @@
 package rocks.metaldetector.security.handler;
 
 import org.springframework.security.authentication.DisabledException;
+import org.springframework.security.authentication.InternalAuthenticationServiceException;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
 import rocks.metaldetector.config.constants.Endpoints;
@@ -13,7 +14,18 @@ public class CustomAuthenticationFailureHandler implements AuthenticationFailure
 
   @Override
   public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException {
-    String redirectURL = exception instanceof DisabledException ? Endpoints.Guest.LOGIN + "?disabled" : Endpoints.Guest.LOGIN + "?badCredentials";
+    String redirectURL;
+
+    if (exception instanceof DisabledException) {
+      redirectURL = Endpoints.Guest.LOGIN + "?disabled";
+    }
+    else if (exception instanceof InternalAuthenticationServiceException) {
+      redirectURL = Endpoints.Guest.LOGIN + "?blocked";
+    }
+    else {
+      redirectURL = Endpoints.Guest.LOGIN + "?badCredentials";
+    }
+
     response.sendRedirect(redirectURL);
   }
 }

--- a/webapp/src/main/java/rocks/metaldetector/security/handler/CustomAuthenticationSuccessHandler.java
+++ b/webapp/src/main/java/rocks/metaldetector/security/handler/CustomAuthenticationSuccessHandler.java
@@ -24,7 +24,6 @@ public class CustomAuthenticationSuccessHandler implements AuthenticationSuccess
 
   @Override
   public void onAuthenticationSuccess(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse, Authentication authentication) throws ServletException, IOException {
-    persistSuccessfulLogin();
     handleRedirect(httpServletRequest, httpServletResponse, authentication);
   }
 
@@ -45,9 +44,5 @@ public class CustomAuthenticationSuccessHandler implements AuthenticationSuccess
       // redirect to requested page
       savedRequestRedirectionHandler.onAuthenticationSuccess(httpServletRequest, httpServletResponse, authentication);
     }
-  }
-
-  private void persistSuccessfulLogin() {
-    // ToDo: persist date and time of login (https://trello.com/c/VxTNVHQ6)
   }
 }

--- a/webapp/src/main/java/rocks/metaldetector/service/exceptions/RestExceptionsHandler.java
+++ b/webapp/src/main/java/rocks/metaldetector/service/exceptions/RestExceptionsHandler.java
@@ -61,7 +61,7 @@ public class RestExceptionsHandler {
     return new ResponseEntity<>(createErrorResponse(exception), new HttpHeaders(), UNSUPPORTED_MEDIA_TYPE);
   }
 
-  @ExceptionHandler(value = MethodArgumentNotValidException.class)
+  @ExceptionHandler({MethodArgumentNotValidException.class})
   public ResponseEntity<ErrorResponse> handleValidationErrors(MethodArgumentNotValidException exception, WebRequest webRequest) {
     log.warn(webRequest.getContextPath() + ": " + exception.getMessage());
     return new ResponseEntity<>(createErrorResponse(exception), new HttpHeaders(), BAD_REQUEST);
@@ -91,7 +91,7 @@ public class RestExceptionsHandler {
     return new ResponseEntity<>(createErrorResponse(exception), new HttpHeaders(), UNPROCESSABLE_ENTITY);
   }
 
-  @ExceptionHandler(value = {ExternalServiceException.class})
+  @ExceptionHandler({ExternalServiceException.class})
   public ResponseEntity<ErrorResponse> handleExternalServiceException(RuntimeException exception, WebRequest webRequest) {
     log.error(webRequest.getContextPath() + ": " + exception.getMessage());
     return new ResponseEntity<>(createErrorResponse(exception), new HttpHeaders(), HttpStatus.SERVICE_UNAVAILABLE);

--- a/webapp/src/main/java/rocks/metaldetector/service/user/UserService.java
+++ b/webapp/src/main/java/rocks/metaldetector/service/user/UserService.java
@@ -31,6 +31,4 @@ public interface UserService extends UserDetailsService {
 
   void persistSuccessfulLogin(String publicUserId);
 
-  void handleFailedLogin(String username);
-	
 }

--- a/webapp/src/main/resources/config/cache/ehcache.xml
+++ b/webapp/src/main/resources/config/cache/ehcache.xml
@@ -25,7 +25,7 @@
         </listeners>
 
         <resources>
-            <heap>1000</heap>
+            <heap unit="MB">10</heap>
         </resources>
     </cache>
 

--- a/webapp/src/main/resources/config/cache/ehcache.xml
+++ b/webapp/src/main/resources/config/cache/ehcache.xml
@@ -1,15 +1,34 @@
 <config xmlns='http://www.ehcache.org/v3'
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xmlns:jsr107="http://www.ehcache.org/v3/jsr107"
-        xsi:schemaLocation="http://www.ehcache.org/v3 http://www.ehcache.org/schema/ehcache-core-3.0.xsd
-							http://www.ehcache.org/v3/jsr107 http://www.ehcache.org/schema/ehcache-107-ext-3.0.xsd">
+        xsi:schemaLocation="http://www.ehcache.org/v3 http://www.ehcache.org/schema/ehcache-core-3.0.xsd">
 
-    <cache alias="dummy">
+    <persistence directory="spring-boot-ehcache/cache" />
+
+    <cache alias="failedLogins">
+        <key-type>java.lang.Integer</key-type>
+        <value-type>java.lang.Long</value-type>
+
         <expiry>
-            <ttl unit="seconds">3600</ttl>
+            <ttl unit="hours">24</ttl>
         </expiry>
-        <heap unit="entries">1000</heap>
-        <jsr107:mbeans enable-statistics="true"/>
+
+        <listeners>
+            <listener>
+                <class>rocks.metaldetector.config.logging.CacheLogger</class>
+                <event-firing-mode>ASYNCHRONOUS</event-firing-mode>
+                <event-ordering-mode>UNORDERED</event-ordering-mode>
+                <events-to-fire-on>CREATED</events-to-fire-on>
+                <events-to-fire-on>EXPIRED</events-to-fire-on>
+                <events-to-fire-on>UPDATED</events-to-fire-on>
+                <events-to-fire-on>EVICTED</events-to-fire-on>
+            </listener>
+        </listeners>
+
+        <resources>
+            <heap>1000</heap>
+            <offheap unit="MB">10</offheap>
+            <disk persistent="true" unit="MB">20</disk>
+        </resources>
     </cache>
 
 </config>

--- a/webapp/src/main/resources/config/cache/ehcache.xml
+++ b/webapp/src/main/resources/config/cache/ehcache.xml
@@ -5,8 +5,8 @@
     <persistence directory="spring-boot-ehcache/cache" />
 
     <cache alias="failedLogins">
-        <key-type>java.lang.Integer</key-type>
-        <value-type>java.lang.Long</value-type>
+        <key-type>java.lang.String</key-type>
+        <value-type>java.lang.Integer</value-type>
 
         <expiry>
             <ttl unit="hours">24</ttl>
@@ -26,8 +26,6 @@
 
         <resources>
             <heap>1000</heap>
-            <offheap unit="MB">10</offheap>
-            <disk persistent="true" unit="MB">20</disk>
         </resources>
     </cache>
 

--- a/webapp/src/main/resources/templates/guest/auth/login.html
+++ b/webapp/src/main/resources/templates/guest/auth/login.html
@@ -10,7 +10,7 @@
       <!-- Login Messages -->
       <div th:if="${param.badCredentials}" class="alert alert-danger" role="alert"><span>Invalid username, email or password!</span></div>
       <div th:if="${param.disabled}" class="alert alert-danger" role="alert"><span>Your account is disabled. Maybe your email address is not verified. Please check your email inbox.</span></div>
-      <div th:if="${param.blocked}" class="alert alert-danger" role="alert"><span>Your account is blocked for one day due to too many failed login requests.</span></div>
+      <div th:if="${param.blocked}" class="alert alert-danger" role="alert"><span>Your ip is blocked for one day due to too many failed login requests.</span></div>
       <div th:if="${param.error}" class="alert alert-danger" role="alert"><span>Unknown error!</span></div>
       <div th:if="${param.logout}" class="alert alert-success" role="alert"><span>You have been successfully logged out.</span></div>
 

--- a/webapp/src/main/resources/templates/guest/auth/login.html
+++ b/webapp/src/main/resources/templates/guest/auth/login.html
@@ -10,6 +10,7 @@
       <!-- Login Messages -->
       <div th:if="${param.badCredentials}" class="alert alert-danger" role="alert"><span>Invalid username, email or password!</span></div>
       <div th:if="${param.disabled}" class="alert alert-danger" role="alert"><span>Your account is disabled. Maybe your email address is not verified. Please check your email inbox.</span></div>
+      <div th:if="${param.blocked}" class="alert alert-danger" role="alert"><span>Your account is blocked for one day due to too many failed login requests.</span></div>
       <div th:if="${param.error}" class="alert alert-danger" role="alert"><span>Unknown error!</span></div>
       <div th:if="${param.logout}" class="alert alert-success" role="alert"><span>You have been successfully logged out.</span></div>
 

--- a/webapp/src/test/java/rocks/metaldetector/security/AuthenticationListenerTest.java
+++ b/webapp/src/test/java/rocks/metaldetector/security/AuthenticationListenerTest.java
@@ -30,9 +30,6 @@ class AuthenticationListenerTest {
   @Mock
   private UserService userService;
 
-  @Mock
-  private CurrentUserSupplier currentUserSupplier;
-
   @InjectMocks
   private AuthenticationListener underTest;
 
@@ -48,12 +45,10 @@ class AuthenticationListenerTest {
   @Mock
   private WebAuthenticationDetails webAuthenticationDetails;
 
-  UserEntity userEntity = UserFactory.createUser("user", "mail");
-
   @AfterEach
   void tearDown() {
     reset(webAuthenticationDetails, successEvent, failureEvent, authentication, webAuthenticationDetails,
-          loginAttemptService, userService, currentUserSupplier);
+          loginAttemptService, userService);
   }
 
   @Test
@@ -65,7 +60,6 @@ class AuthenticationListenerTest {
     when(successEvent.getAuthentication()).thenReturn(authentication);
     when(authentication.getDetails()).thenReturn(webAuthenticationDetails);
     when(webAuthenticationDetails.getRemoteAddress()).thenReturn(ip);
-    when(currentUserSupplier.get()).thenReturn(userEntity);
 
     // when
     underTest.onAuthenticationSuccess(successEvent);
@@ -78,17 +72,18 @@ class AuthenticationListenerTest {
   @DisplayName("UserService is called to persist login on authentication success")
   void authentication_success_calls_user_service() {
     // given
+    UserEntity userEntity = UserFactory.createUser("user", "email");
+    userEntity.setPublicId("publicId");
     when(successEvent.getAuthentication()).thenReturn(authentication);
     when(authentication.getDetails()).thenReturn(webAuthenticationDetails);
+    when(authentication.getPrincipal()).thenReturn(userEntity);
     when(webAuthenticationDetails.getRemoteAddress()).thenReturn("i'm an ip");
-    when(currentUserSupplier.get()).thenReturn(userEntity);
 
     // when
     underTest.onAuthenticationSuccess(successEvent);
 
     // then
     verify(userService, times(1)).persistSuccessfulLogin(userEntity.getPublicId());
-    verify(currentUserSupplier, times(1)).get();
   }
 
   @Test

--- a/webapp/src/test/java/rocks/metaldetector/security/AuthenticationListenerTest.java
+++ b/webapp/src/test/java/rocks/metaldetector/security/AuthenticationListenerTest.java
@@ -49,7 +49,7 @@ class AuthenticationListenerTest {
 
   @AfterEach
   void tearDown() {
-    reset(webAuthenticationDetails, successEvent, failureEvent, authentication, webAuthenticationDetails,
+    reset(successEvent, failureEvent, authentication, webAuthenticationDetails,
           loginAttemptService, userService, userEntity);
   }
 

--- a/webapp/src/test/java/rocks/metaldetector/security/LoginAttemptServiceTest.java
+++ b/webapp/src/test/java/rocks/metaldetector/security/LoginAttemptServiceTest.java
@@ -54,7 +54,7 @@ class LoginAttemptServiceTest implements WithAssertions {
   }
 
   @Test
-  @DisplayName("Cache is fetched from manager to check for blocked user")
+  @DisplayName("Cache is fetched from manager to check for blocked ip")
   void checking_blocked_users_gets_cache_from_manager() {
     // when
     underTest.isBlocked("666");
@@ -64,7 +64,7 @@ class LoginAttemptServiceTest implements WithAssertions {
   }
 
   @Test
-  @DisplayName("User is blocked if the cached value is bigger than 4")
+  @DisplayName("Ip is blocked if the cached value is bigger than 4")
   void user_counts_as_blocked() {
     // given
     String ipHash = "666";
@@ -79,7 +79,7 @@ class LoginAttemptServiceTest implements WithAssertions {
   }
 
   @Test
-  @DisplayName("User is blocked if the cache could not be fetched")
+  @DisplayName("Ip is blocked if the cache could not be fetched")
   void user_counts_as_blocked_if_cache_not_present() {
     // given
     when(cacheManager.getCache(FAILED_LOGINS_CACHE)).thenReturn(null);
@@ -92,7 +92,7 @@ class LoginAttemptServiceTest implements WithAssertions {
   }
 
   @Test
-  @DisplayName("User is not blocked if the cached value is smaller than 5")
+  @DisplayName("Ip is not blocked if the cached value is smaller than 5")
   void user_does_not_count_as_blocked() {
     // given
     String ipHash = "666";

--- a/webapp/src/test/java/rocks/metaldetector/security/LoginAttemptServiceTest.java
+++ b/webapp/src/test/java/rocks/metaldetector/security/LoginAttemptServiceTest.java
@@ -1,39 +1,108 @@
 package rocks.metaldetector.security;
 
-import org.ehcache.Cache;
+import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
 
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static rocks.metaldetector.security.LoginAttemptService.FAILED_LOGINS_CACHE;
 
-class LoginAttemptServiceTest {
+@ExtendWith(MockitoExtension.class)
+class LoginAttemptServiceTest implements WithAssertions {
 
   @Mock
-  private Cache<Integer, Long> cache;
+  private CacheManager cacheManager;
+
+  @Mock
+  private Cache cache;
+
+  @Mock
+  private Cache.ValueWrapper valueWrapper;
 
   @InjectMocks
   private LoginAttemptService underTest;
 
+  @BeforeEach
+  void setup() {
+    when(cacheManager.getCache(FAILED_LOGINS_CACHE)).thenReturn(cache);
+  }
+
   @AfterEach
   void tearDown() {
-    reset(cache);
+    reset(cacheManager, cache, valueWrapper);
   }
 
   @Test
-  @DisplayName("Cache is cleared on successful login")
-  void successful_login_clears_cache() {
-    // given
-    int ipHash = 123;
-
+  @DisplayName("Cache is fetched from manager on failed login")
+  void failed_login_gets_cache_from_manager() {
     // when
-    underTest.loginSucceeded(ipHash);
+    underTest.loginFailed("666");
 
     // then
-    verify(cache, times(1)).remove(ipHash);
+    verify(cacheManager, times(1)).getCache(FAILED_LOGINS_CACHE);
+  }
+
+  @Test
+  @DisplayName("Cache is fetched from manager to check for blocked user")
+  void checking_blocked_users_gets_cache_from_manager() {
+    // when
+    underTest.isBlocked("666");
+
+    // then
+    verify(cacheManager, times(1)).getCache(FAILED_LOGINS_CACHE);
+  }
+
+  @Test
+  @DisplayName("User is blocked if the cached value is bigger than 4")
+  void user_counts_as_blocked() {
+    // given
+    String ipHash = "666";
+    when(cache.get(ipHash)).thenReturn(valueWrapper);
+    when(valueWrapper.get()).thenReturn(5);
+
+    // when
+    var result = underTest.isBlocked(ipHash);
+
+    // then
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  @DisplayName("User is blocked if the cache could not be fetched")
+  void user_counts_as_blocked_if_cache_not_present() {
+    // given
+    when(cacheManager.getCache(FAILED_LOGINS_CACHE)).thenReturn(null);
+
+    // when
+    var result = underTest.isBlocked("666");
+
+    // then
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  @DisplayName("User is not blocked if the cached value is smaller than 5")
+  void user_does_not_count_as_blocked() {
+    // given
+    String ipHash = "666";
+    when(cache.get(ipHash)).thenReturn(valueWrapper);
+    when(valueWrapper.get()).thenReturn(1);
+
+    // when
+    var result = underTest.isBlocked(ipHash);
+
+    // then
+    assertThat(result).isFalse();
   }
 }

--- a/webapp/src/test/java/rocks/metaldetector/security/LoginAttemptServiceTest.java
+++ b/webapp/src/test/java/rocks/metaldetector/security/LoginAttemptServiceTest.java
@@ -1,0 +1,39 @@
+package rocks.metaldetector.security;
+
+import org.ehcache.Cache;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+class LoginAttemptServiceTest {
+
+  @Mock
+  private Cache<Integer, Long> cache;
+
+  @InjectMocks
+  private LoginAttemptService underTest;
+
+  @AfterEach
+  void tearDown() {
+    reset(cache);
+  }
+
+  @Test
+  @DisplayName("Cache is cleared on successful login")
+  void successful_login_clears_cache() {
+    // given
+    int ipHash = 123;
+
+    // when
+    underTest.loginSucceeded(ipHash);
+
+    // then
+    verify(cache, times(1)).remove(ipHash);
+  }
+}

--- a/webapp/src/test/java/rocks/metaldetector/security/handler/CustomAuthenticationFailureHandlerTest.java
+++ b/webapp/src/test/java/rocks/metaldetector/security/handler/CustomAuthenticationFailureHandlerTest.java
@@ -10,38 +10,53 @@ import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.DisabledException;
+import org.springframework.security.authentication.InternalAuthenticationServiceException;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
 import rocks.metaldetector.config.constants.Endpoints;
 
 class CustomAuthenticationFailureHandlerTest implements WithAssertions {
 
-  private AuthenticationFailureHandler authenticationFailureHandler;
-  private MockHttpServletRequest       httpServletRequest;
-  private MockHttpServletResponse      httpServletResponse;
+  private AuthenticationFailureHandler underTest;
+  private MockHttpServletRequest httpServletRequest;
+  private MockHttpServletResponse httpServletResponse;
 
   @BeforeEach
   void setup() {
-    authenticationFailureHandler = new CustomAuthenticationFailureHandler();
-    httpServletRequest           = new MockHttpServletRequest();
-    httpServletResponse          = new MockHttpServletResponse();
+    underTest = new CustomAuthenticationFailureHandler();
+    httpServletRequest = new MockHttpServletRequest();
+    httpServletResponse = new MockHttpServletResponse();
   }
 
   @Test
   @DisplayName("Forward user to login page again if the user is disabled")
   void forward_to_login_page_if_user_is_disabled() throws Exception {
-    authenticationFailureHandler.onAuthenticationFailure(httpServletRequest, httpServletResponse, new DisabledException("dummy"));
+    // when
+    underTest.onAuthenticationFailure(httpServletRequest, httpServletResponse, new DisabledException("dummy"));
 
+    // then
     assertThat(httpServletResponse.getStatus()).isEqualTo(HttpStatus.FOUND.value());
     assertThat(httpServletResponse.getHeader(HttpHeaders.LOCATION)).isEqualTo(Endpoints.Guest.LOGIN + "?disabled");
   }
 
   @Test
+  @DisplayName("Forward user to login page again if the user is blocked")
+  void forward_to_login_page_if_user_is_blocked() throws Exception {
+    // when
+    underTest.onAuthenticationFailure(httpServletRequest, httpServletResponse, new InternalAuthenticationServiceException("dummy"));
+
+    // then
+    assertThat(httpServletResponse.getStatus()).isEqualTo(HttpStatus.FOUND.value());
+    assertThat(httpServletResponse.getHeader(HttpHeaders.LOCATION)).isEqualTo(Endpoints.Guest.LOGIN + "?blocked");
+  }
+
+  @Test
   @DisplayName("Forward user to login page again if the user has bad credentials")
   void forward_to_login_page_if_user_has_bad_credentials() throws Exception {
-    authenticationFailureHandler.onAuthenticationFailure(httpServletRequest, httpServletResponse, new BadCredentialsException("dummy"));
+    // when
+    underTest.onAuthenticationFailure(httpServletRequest, httpServletResponse, new BadCredentialsException("dummy"));
 
+    // then
     assertThat(httpServletResponse.getStatus()).isEqualTo(HttpStatus.FOUND.value());
     assertThat(httpServletResponse.getRedirectedUrl()).isEqualTo(Endpoints.Guest.LOGIN + "?badCredentials");
   }
-
 }

--- a/webapp/src/test/java/rocks/metaldetector/service/user/UserServiceTest.java
+++ b/webapp/src/test/java/rocks/metaldetector/service/user/UserServiceTest.java
@@ -359,8 +359,8 @@ class UserServiceTest implements WithAssertions {
     }
 
     @Test
-    @DisplayName("Requesting a blocked user by email or username should throw an exception")
-    void get_user_by_email_or_username_for_blocked_user() {
+    @DisplayName("Requesting a user by email or username via blocked ip should throw an exception")
+    void get_user_by_email_or_username_from_blocked_ip() {
       // given
       when(request.getHeader(anyString())).thenReturn("666");
       when(loginAttemptService.isBlocked(anyString())).thenReturn(true);


### PR DESCRIPTION
Failed logins are cached for 24 hours (hashed IP and the amount of attemps). If there are more than five failed attempts the IP is blocked for 24 hours.