### PR TITLE
Create null safe service to pretty print enum values

### DIFF
--- a/butler/src/main/java/rocks/metaldetector/butler/client/transformer/ButlerReleaseResponseTransformer.java
+++ b/butler/src/main/java/rocks/metaldetector/butler/client/transformer/ButlerReleaseResponseTransformer.java
@@ -1,18 +1,22 @@
 package rocks.metaldetector.butler.client.transformer;
 
-import org.apache.commons.text.WordUtils;
+import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
 import rocks.metaldetector.butler.api.ButlerRelease;
 import rocks.metaldetector.butler.api.ButlerReleasesResponse;
 import rocks.metaldetector.butler.facade.dto.ReleaseDto;
+import rocks.metaldetector.support.EnumPrettyPrinter;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
 @Service
+@AllArgsConstructor
 public class ButlerReleaseResponseTransformer {
 
-  private static final String STATE_NOT_SET = "NOT_SET";
+  private final EnumPrettyPrinter enumPrettyPrinter;
+
+  static final String STATE_NOT_SET = "NOT_SET";
 
   public List<ReleaseDto> transform(ButlerReleasesResponse response) {
     return response.getReleases().stream().map(this::transformRelease).collect(Collectors.toList());
@@ -26,15 +30,11 @@ public class ButlerReleaseResponseTransformer {
             .releaseDate(release.getReleaseDate())
             .estimatedReleaseDate(release.getEstimatedReleaseDate())
             .genre(release.getGenre())
-            .type(prettyPrintValue(release.getType()))
+            .type(enumPrettyPrinter.prettyPrintEnumValue(release.getType()))
             .metalArchivesArtistUrl(release.getMetalArchivesArtistUrl())
             .metalArchivesAlbumUrl(release.getMetalArchivesAlbumUrl())
-            .source(prettyPrintValue(release.getSource()))
-            .state(prettyPrintValue(STATE_NOT_SET))
+            .source(enumPrettyPrinter.prettyPrintEnumValue(release.getSource()))
+            .state(enumPrettyPrinter.prettyPrintEnumValue(STATE_NOT_SET))
             .build();
-  }
-
-  private String prettyPrintValue(String value) {
-    return WordUtils.capitalizeFully(value.replace("_", " "));
   }
 }

--- a/butler/src/test/java/rocks/metaldetector/butler/client/transformer/ButlerReleaseResponseTransformerTest.java
+++ b/butler/src/test/java/rocks/metaldetector/butler/client/transformer/ButlerReleaseResponseTransformerTest.java
@@ -4,22 +4,37 @@ import org.apache.commons.text.WordUtils;
 import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import rocks.metaldetector.butler.ButlerDtoFactory;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import rocks.metaldetector.butler.ButlerDtoFactory.ButlerReleaseFactory;
 import rocks.metaldetector.butler.api.ButlerRelease;
 import rocks.metaldetector.butler.api.ButlerReleasesResponse;
 import rocks.metaldetector.butler.facade.dto.ReleaseDto;
+import rocks.metaldetector.support.EnumPrettyPrinter;
 
 import java.util.List;
 
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static rocks.metaldetector.butler.client.transformer.ButlerReleaseResponseTransformer.STATE_NOT_SET;
+
+@ExtendWith(MockitoExtension.class)
 class ButlerReleaseResponseTransformerTest implements WithAssertions {
 
-  private ButlerReleaseResponseTransformer underTest = new ButlerReleaseResponseTransformer();
+  @Spy
+  private EnumPrettyPrinter enumPrettyPrinter;
+
+  @InjectMocks
+  private ButlerReleaseResponseTransformer underTest;
 
   @Test
   @DisplayName("Should transform ButlerReleaseResponse to list of ReleaseDto")
   void should_transform() {
     // given
-    ButlerRelease release = ButlerDtoFactory.ButlerReleaseFactory.createDefault();
+    ButlerRelease release = ButlerReleaseFactory.createDefault();
     ButlerReleasesResponse response = ButlerReleasesResponse.builder().releases(List.of(release)).build();
 
     // when
@@ -41,5 +56,21 @@ class ButlerReleaseResponseTransformerTest implements WithAssertions {
     assertThat(releaseDto.getMetalArchivesAlbumUrl()).isEqualTo(release.getMetalArchivesAlbumUrl());
     assertThat(releaseDto.getSource()).isEqualTo(WordUtils.capitalizeFully(release.getSource()));
     assertThat(releaseDto.getState()).isEqualTo(WordUtils.capitalizeFully(release.getState()));
+  }
+
+  @Test
+  @DisplayName("Should use enum pretty printer to transform enum values")
+  void should_use_enum_pretty_printer() {
+    // given
+    ButlerRelease release = ButlerReleaseFactory.createDefault();
+    ButlerReleasesResponse response = ButlerReleasesResponse.builder().releases(List.of(release)).build();
+
+    // when
+    underTest.transform(response);
+
+    // then
+    verify(enumPrettyPrinter, times(1)).prettyPrintEnumValue(eq(release.getType()));
+    verify(enumPrettyPrinter, times(1)).prettyPrintEnumValue(eq(release.getSource()));
+    verify(enumPrettyPrinter, times(1)).prettyPrintEnumValue(eq(STATE_NOT_SET));
   }
 }

--- a/support/src/main/java/rocks/metaldetector/support/EnumPrettyPrinter.java
+++ b/support/src/main/java/rocks/metaldetector/support/EnumPrettyPrinter.java
@@ -1,0 +1,12 @@
+package rocks.metaldetector.support;
+
+import org.apache.commons.text.WordUtils;
+import org.springframework.stereotype.Service;
+
+@Service
+public class EnumPrettyPrinter {
+
+  public String prettyPrintEnumValue(String value) {
+    return value != null ? WordUtils.capitalizeFully(value.replace("_", " ")).trim() : null;
+  }
+}

--- a/support/src/test/java/rocks/metaldetector/support/EnumPrettyPrinterTest.java
+++ b/support/src/test/java/rocks/metaldetector/support/EnumPrettyPrinterTest.java
@@ -1,0 +1,46 @@
+package rocks.metaldetector.support;
+
+import org.assertj.core.api.WithAssertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+class EnumPrettyPrinterTest implements WithAssertions {
+
+  private final EnumPrettyPrinter underTest = new EnumPrettyPrinter();
+
+  @Test
+  @DisplayName("Should be null safe")
+  void should_be_null_safe() {
+    // when
+    String result = underTest.prettyPrintEnumValue(null);
+
+    // then
+    assertThat(result).isNull();
+  }
+
+  @ParameterizedTest(name = "Should transform <{0}> to <{1}>")
+  @MethodSource("valueProvider")
+  @DisplayName("Should transform the given value fully capitalized")
+  void should_transform_fully_capitalized(String givenValue, String expectedValue) {
+    // when
+    String result = underTest.prettyPrintEnumValue(givenValue);
+
+    // then
+    assertThat(result).isEqualTo(expectedValue);
+  }
+
+  private static Stream<Arguments> valueProvider() {
+    return Stream.of(
+            Arguments.of("value", "Value"),
+            Arguments.of("_value_", "Value"),
+            Arguments.of("example_value", "Example Value"),
+            Arguments.of("EXAMPLE_VALUE", "Example Value"),
+            Arguments.of("eXAMPLE_vALUE", "Example Value")
+    );
+  }
+}


### PR DESCRIPTION
This fixes the current NPE we have in the Admin Area when loading the releases.