### PR TITLE
Refactoring of artist id

### DIFF
--- a/discogs/src/main/java/rocks/metaldetector/discogs/client/DiscogsArtistSearchRestClient.java
+++ b/discogs/src/main/java/rocks/metaldetector/discogs/client/DiscogsArtistSearchRestClient.java
@@ -3,12 +3,10 @@ package rocks.metaldetector.discogs.client;
 import rocks.metaldetector.discogs.api.DiscogsArtist;
 import rocks.metaldetector.discogs.api.DiscogsArtistSearchResultContainer;
 
-import java.util.Optional;
-
 public interface DiscogsArtistSearchRestClient {
 
   DiscogsArtistSearchResultContainer searchByName(String artistQueryString, int pageNumber, int pageSize);
 
-  DiscogsArtist searchById(long artistId);
+  DiscogsArtist searchById(String externalId);
 
 }

--- a/discogs/src/main/java/rocks/metaldetector/discogs/client/DiscogsArtistSearchRestClientImpl.java
+++ b/discogs/src/main/java/rocks/metaldetector/discogs/client/DiscogsArtistSearchRestClientImpl.java
@@ -52,21 +52,21 @@ public class DiscogsArtistSearchRestClientImpl implements DiscogsArtistSearchRes
   }
 
   @Override
-  public DiscogsArtist searchById(long artistId) {
-    if (artistId <= 0) {
-      throw new IllegalArgumentException("artistId must not be negative!");
+  public DiscogsArtist searchById(String externalId) {
+    if (externalId.isBlank()) {
+      throw new IllegalArgumentException("externalId must not be blank!");
     }
 
     ResponseEntity<DiscogsArtist> responseEntity = discogsRestTemplate.getForEntity(
             discogsConfig.getRestBaseUrl() + ARTIST_ID_SEARCH_URL_FRAGMENT,
             DiscogsArtist.class,
-            artistId
+            externalId
     );
 
     DiscogsArtist discogsArtist = responseEntity.getBody();
     var shouldNotHappen = discogsArtist == null || !responseEntity.getStatusCode().is2xxSuccessful();
     if (shouldNotHappen) {
-      throw new ExternalServiceException("Could not get artist for artistId '" + artistId + "' (Response code: " + responseEntity.getStatusCode() + ")");
+      throw new ExternalServiceException("Could not get artist for externalId '" + externalId + "' (Response code: " + responseEntity.getStatusCode() + ")");
     }
 
     return discogsArtist;

--- a/discogs/src/main/java/rocks/metaldetector/discogs/client/DiscogsArtistSearchRestClientImpl.java
+++ b/discogs/src/main/java/rocks/metaldetector/discogs/client/DiscogsArtistSearchRestClientImpl.java
@@ -53,7 +53,7 @@ public class DiscogsArtistSearchRestClientImpl implements DiscogsArtistSearchRes
 
   @Override
   public DiscogsArtist searchById(String externalId) {
-    if (externalId.isEmpty()) {
+    if (externalId == null || externalId.isEmpty()) {
       throw new IllegalArgumentException("externalId must not be empty");
     }
 

--- a/discogs/src/main/java/rocks/metaldetector/discogs/client/DiscogsArtistSearchRestClientImpl.java
+++ b/discogs/src/main/java/rocks/metaldetector/discogs/client/DiscogsArtistSearchRestClientImpl.java
@@ -53,8 +53,8 @@ public class DiscogsArtistSearchRestClientImpl implements DiscogsArtistSearchRes
 
   @Override
   public DiscogsArtist searchById(String externalId) {
-    if (externalId.isBlank()) {
-      throw new IllegalArgumentException("externalId must not be blank!");
+    if (externalId.isEmpty()) {
+      throw new IllegalArgumentException("externalId must not be empty");
     }
 
     ResponseEntity<DiscogsArtist> responseEntity = discogsRestTemplate.getForEntity(

--- a/discogs/src/main/java/rocks/metaldetector/discogs/client/DiscogsArtistSearchRestClientMock.java
+++ b/discogs/src/main/java/rocks/metaldetector/discogs/client/DiscogsArtistSearchRestClientMock.java
@@ -14,8 +14,8 @@ import java.util.List;
 @Profile("mockmode")
 public class DiscogsArtistSearchRestClientMock implements DiscogsArtistSearchRestClient {
 
-  static final long METALLICA_ID = 18839;
-  static final long SLAYER_ID = 18845;
+  static final String METALLICA_ID = "18839";
+  static final String SLAYER_ID = "18845";
 
   private static final String METALLICA_IMAGE_URL = "https://img.discogs.com/jJVZAoJsAzrXr3qWDEWfXkM6GOQ=/fit-in/300x300/filters:strip_icc():format(jpeg):mode_rgb():quality(40)/discogs-images/A-18839-1577045241-6198.jpeg.jpg";
   private static final String SLAYER_IMAGE_URL = "https://img.discogs.com/V6DQdkTXpXe-v5X3Inzrj-rMPMk=/fit-in/300x300/filters:strip_icc():format(jpeg):mode_rgb():quality(40)/discogs-images/A-18845-1546167009-4213.jpeg.jpg";
@@ -29,17 +29,17 @@ public class DiscogsArtistSearchRestClientMock implements DiscogsArtistSearchRes
   }
 
   @Override
-  public DiscogsArtist searchById(long artistId) {
-    if (artistId == METALLICA_ID) {
+  public DiscogsArtist searchById(String externalId) {
+    if (externalId.equals(METALLICA_ID)) {
       return DiscogsArtist.builder()
-              .id(METALLICA_ID)
+              .id(Long.parseLong(METALLICA_ID))
               .name("Metallica")
               .images(List.of(DiscogsImage.builder().resourceUrl(METALLICA_IMAGE_URL).build()))
               .build();
     }
-    else if (artistId == SLAYER_ID) {
+    else if (externalId.equals(SLAYER_ID)) {
       return DiscogsArtist.builder()
-              .id(SLAYER_ID)
+              .id(Long.parseLong(SLAYER_ID))
               .name("Slayer")
               .images(List.of(DiscogsImage.builder().resourceUrl(SLAYER_IMAGE_URL).build()))
               .build();
@@ -51,7 +51,7 @@ public class DiscogsArtistSearchRestClientMock implements DiscogsArtistSearchRes
 
   private DiscogsArtistSearchResult createMetallica() {
     return DiscogsArtistSearchResult.builder()
-            .id(METALLICA_ID)
+            .id(Long.parseLong(METALLICA_ID))
             .title("Metallica")
             .resourceUrl("https://www.discogs.com/de/artist/18839-Metallica")
             .thumb(METALLICA_IMAGE_URL)
@@ -60,7 +60,7 @@ public class DiscogsArtistSearchRestClientMock implements DiscogsArtistSearchRes
 
   private DiscogsArtistSearchResult createSlayer() {
     return DiscogsArtistSearchResult.builder()
-            .id(SLAYER_ID)
+            .id(Long.parseLong(SLAYER_ID))
             .title("Slayer")
             .resourceUrl("https://www.discogs.com/de/artist/18845-Slayer")
             .thumb(SLAYER_IMAGE_URL)

--- a/discogs/src/main/java/rocks/metaldetector/discogs/client/transformer/DiscogsArtistSearchResultContainerTransformer.java
+++ b/discogs/src/main/java/rocks/metaldetector/discogs/client/transformer/DiscogsArtistSearchResultContainerTransformer.java
@@ -37,7 +37,7 @@ public class DiscogsArtistSearchResultContainerTransformer {
 
   private DiscogsArtistSearchResultEntryDto transformArtistSearchResult(DiscogsArtistSearchResult result) {
     return DiscogsArtistSearchResultEntryDto.builder()
-            .id(result.getId())
+            .id(String.valueOf(result.getId()))
             .name(result.getTitle())
             .imageUrl(result.getThumb())
             .uri(result.getUri())

--- a/discogs/src/main/java/rocks/metaldetector/discogs/client/transformer/DiscogsArtistTransformer.java
+++ b/discogs/src/main/java/rocks/metaldetector/discogs/client/transformer/DiscogsArtistTransformer.java
@@ -12,7 +12,7 @@ public class DiscogsArtistTransformer {
   public DiscogsArtistDto transform(DiscogsArtist artist) {
     String imageUrl = artist.getImages() != null && artist.getImages().size() > 0 ? artist.getImages().get(0).getResourceUrl() : null;
     return DiscogsArtistDto.builder()
-            .id(artist.getId())
+            .id(String.valueOf(artist.getId()))
             .name(artist.getName())
             .imageUrl(imageUrl)
             .build();

--- a/discogs/src/main/java/rocks/metaldetector/discogs/facade/DiscogsService.java
+++ b/discogs/src/main/java/rocks/metaldetector/discogs/facade/DiscogsService.java
@@ -7,5 +7,5 @@ public interface DiscogsService {
 
   DiscogsArtistSearchResultDto searchArtistByName(String artistQueryString, int pageNumber, int pageSize);
 
-  DiscogsArtistDto searchArtistById(long artistId);
+  DiscogsArtistDto searchArtistById(String externalId);
 }

--- a/discogs/src/main/java/rocks/metaldetector/discogs/facade/DiscogsServiceImpl.java
+++ b/discogs/src/main/java/rocks/metaldetector/discogs/facade/DiscogsServiceImpl.java
@@ -25,8 +25,8 @@ public class DiscogsServiceImpl implements DiscogsService {
   }
 
   @Override
-  public DiscogsArtistDto searchArtistById(long artistId) {
-    DiscogsArtist result = searchClient.searchById(artistId);
+  public DiscogsArtistDto searchArtistById(String externalId) {
+    DiscogsArtist result = searchClient.searchById(externalId);
     return artistTransformer.transform(result);
   }
 }

--- a/discogs/src/main/java/rocks/metaldetector/discogs/facade/dto/DiscogsArtistDto.java
+++ b/discogs/src/main/java/rocks/metaldetector/discogs/facade/dto/DiscogsArtistDto.java
@@ -3,14 +3,13 @@ package rocks.metaldetector.discogs.facade.dto;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
-import lombok.NoArgsConstructor;
 
 @Data
 @AllArgsConstructor
 @Builder
 public class DiscogsArtistDto {
 
-  private long id;
+  private String id;
   private String name;
   private String imageUrl;
 

--- a/discogs/src/main/java/rocks/metaldetector/discogs/facade/dto/DiscogsArtistSearchResultEntryDto.java
+++ b/discogs/src/main/java/rocks/metaldetector/discogs/facade/dto/DiscogsArtistSearchResultEntryDto.java
@@ -11,7 +11,7 @@ public class DiscogsArtistSearchResultEntryDto {
 
   private static final String DISCOGS_URL = "http://discogs.com";
 
-  private long id;
+  private String id;
   private String name;
   private String imageUrl;
   private String uri;

--- a/discogs/src/test/java/rocks/metaldetector/discogs/client/DiscogsArtistSearchRestClientMockTest.java
+++ b/discogs/src/test/java/rocks/metaldetector/discogs/client/DiscogsArtistSearchRestClientMockTest.java
@@ -31,12 +31,12 @@ class DiscogsArtistSearchRestClientMockTest implements WithAssertions {
   @ParameterizedTest(name = "Should return an artist when searching by id {0}")
   @MethodSource("idProvider")
   @DisplayName("Should return an artist when searching by an known id")
-  void should_return_artist(long artistId) {
+  void should_return_artist(String externalId) {
     // when
-    DiscogsArtist result = underTest.searchById(artistId);
+    DiscogsArtist result = underTest.searchById(externalId);
 
     // then
-    assertThat(result.getId()).isEqualTo(artistId);
+    assertThat(result.getId()).isEqualTo(Long.parseLong(externalId));
   }
 
   private static Stream<Arguments> idProvider() {

--- a/discogs/src/test/java/rocks/metaldetector/discogs/client/DiscogsArtistSearchRestClientTest.java
+++ b/discogs/src/test/java/rocks/metaldetector/discogs/client/DiscogsArtistSearchRestClientTest.java
@@ -26,7 +26,7 @@ import rocks.metaldetector.support.exceptions.ExternalServiceException;
 import java.util.stream.Stream;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.reset;
@@ -177,21 +177,20 @@ class DiscogsArtistSearchRestClientTest implements WithAssertions {
   class SearchByIdTest {
 
     @ParameterizedTest(name = "An IllegalArgumentException is thrown when artistId is [{0}].")
-    @MethodSource("illegalArtistIdProvider")
-    @DisplayName("An IllegalArgumentException is thrown when artistId is less than 1.")
-    void test_invalid_artist_id(long artistId) {
+    @MethodSource("illegalExternalIdProvider")
+    @DisplayName("An IllegalArgumentException is thrown when artistId is blank.")
+    void test_invalid_artist_id(String externalId) {
       // when
-      var throwable = catchThrowable(() -> underTest.searchById(artistId));
+      var throwable = catchThrowable(() -> underTest.searchById(externalId));
 
       // then
       assertThat(throwable).isInstanceOf(IllegalArgumentException.class);
     }
 
-    private Stream<Arguments> illegalArtistIdProvider() {
+    private Stream<Arguments> illegalExternalIdProvider() {
       return Stream.of(
-              Arguments.of(0),
-              Arguments.of(-1),
-              Arguments.of(Long.MIN_VALUE)
+              Arguments.of(""),
+              Arguments.of("   ")
       );
     }
 
@@ -203,22 +202,22 @@ class DiscogsArtistSearchRestClientTest implements WithAssertions {
       doReturn(discogsBaseUrl).when(discogsConfig).getRestBaseUrl();
       var expectedSearchUrl = discogsBaseUrl + ARTIST_ID_SEARCH_URL_FRAGMENT;
       DiscogsArtist responseMock = DiscogsArtistFactory.createDefault();
-      doReturn(ResponseEntity.ok(responseMock)).when(restTemplate).getForEntity(any(), any(), anyLong());
+      doReturn(ResponseEntity.ok(responseMock)).when(restTemplate).getForEntity(any(), any(), anyString());
 
       // when
-      underTest.searchById(123);
+      underTest.searchById("123");
 
       // then
-      verify(restTemplate, times(1)).getForEntity(eq(expectedSearchUrl), any(), anyLong());
+      verify(restTemplate, times(1)).getForEntity(eq(expectedSearchUrl), any(), anyString());
     }
 
     @Test
     @DisplayName("The provided artistId is sent as url parameter.")
     void test_artist_id_as_url_parameter() {
       // given
-      var artistId = 123L;
+      var artistId = "123";
       DiscogsArtist responseMock = DiscogsArtistFactory.createDefault();
-      doReturn(ResponseEntity.ok(responseMock)).when(restTemplate).getForEntity(any(), any(), anyLong());
+      doReturn(ResponseEntity.ok(responseMock)).when(restTemplate).getForEntity(any(), any(), anyString());
 
       // when
       underTest.searchById(artistId);
@@ -232,10 +231,10 @@ class DiscogsArtistSearchRestClientTest implements WithAssertions {
     void test_response_is_returned() {
       // given
       DiscogsArtist responseMock = DiscogsArtistFactory.createDefault();
-      doReturn(ResponseEntity.ok(responseMock)).when(restTemplate).getForEntity(any(), any(), anyLong());
+      doReturn(ResponseEntity.ok(responseMock)).when(restTemplate).getForEntity(any(), any(), anyString());
 
       // when
-      var response = underTest.searchById(123);
+      var response = underTest.searchById("123");
 
       // then
       assertThat(response).isEqualTo(responseMock);
@@ -245,10 +244,10 @@ class DiscogsArtistSearchRestClientTest implements WithAssertions {
     @DisplayName("If the response is null, a ExternalServiceException is thrown")
     void test_exception_if_response_is_null() {
       // given
-      doReturn(ResponseEntity.ok(null)).when(restTemplate).getForEntity(any(), any(), anyLong());
+      doReturn(ResponseEntity.ok(null)).when(restTemplate).getForEntity(any(), any(), anyString());
 
       // when
-      Throwable throwable = catchThrowable(() -> underTest.searchById(123));
+      Throwable throwable = catchThrowable(() -> underTest.searchById("123"));
 
       // then
       assertThat(throwable).isInstanceOf(ExternalServiceException.class);
@@ -260,10 +259,10 @@ class DiscogsArtistSearchRestClientTest implements WithAssertions {
     void test_exception_if_status_is_not_ok(HttpStatus httpStatus) {
       // given
       DiscogsArtist responseMock = DiscogsArtistFactory.createDefault();
-      doReturn(ResponseEntity.status(httpStatus).body(responseMock)).when(restTemplate).getForEntity(any(), any(), anyLong());
+      doReturn(ResponseEntity.status(httpStatus).body(responseMock)).when(restTemplate).getForEntity(any(), any(), anyString());
 
       // when
-      Throwable throwable = catchThrowable(() -> underTest.searchById(123));
+      Throwable throwable = catchThrowable(() -> underTest.searchById("123"));
 
       // then
       assertThat(throwable).isInstanceOf(ExternalServiceException.class);

--- a/discogs/src/test/java/rocks/metaldetector/discogs/client/DiscogsArtistSearchRestClientTest.java
+++ b/discogs/src/test/java/rocks/metaldetector/discogs/client/DiscogsArtistSearchRestClientTest.java
@@ -176,22 +176,14 @@ class DiscogsArtistSearchRestClientTest implements WithAssertions {
   @DisplayName("Tests for method searchById()")
   class SearchByIdTest {
 
-    @ParameterizedTest(name = "An IllegalArgumentException is thrown when artistId is [{0}].")
-    @MethodSource("illegalExternalIdProvider")
-    @DisplayName("An IllegalArgumentException is thrown when artistId is blank.")
-    void test_invalid_artist_id(String externalId) {
+    @Test
+    @DisplayName("An IllegalArgumentException is thrown when artistId is empty.")
+    void test_invalid_artist_id() {
       // when
-      var throwable = catchThrowable(() -> underTest.searchById(externalId));
+      var throwable = catchThrowable(() -> underTest.searchById(""));
 
       // then
       assertThat(throwable).isInstanceOf(IllegalArgumentException.class);
-    }
-
-    private Stream<Arguments> illegalExternalIdProvider() {
-      return Stream.of(
-              Arguments.of(""),
-              Arguments.of("   ")
-      );
     }
 
     @Test

--- a/discogs/src/test/java/rocks/metaldetector/discogs/client/DiscogsArtistSearchRestClientTest.java
+++ b/discogs/src/test/java/rocks/metaldetector/discogs/client/DiscogsArtistSearchRestClientTest.java
@@ -176,11 +176,12 @@ class DiscogsArtistSearchRestClientTest implements WithAssertions {
   @DisplayName("Tests for method searchById()")
   class SearchByIdTest {
 
-    @Test
-    @DisplayName("An IllegalArgumentException is thrown when artistId is empty.")
-    void test_invalid_artist_id() {
+    @ParameterizedTest(name = "If the artistId is '{0}', an IllegalArgumentException is thrown")
+    @MethodSource("invalidArtistIdProvider")
+    @DisplayName("An IllegalArgumentException is thrown when artistId is invalid.")
+    void test_invalid_artist_id(String artistId) {
       // when
-      var throwable = catchThrowable(() -> underTest.searchById(""));
+      var throwable = catchThrowable(() -> underTest.searchById(artistId));
 
       // then
       assertThat(throwable).isInstanceOf(IllegalArgumentException.class);
@@ -258,6 +259,13 @@ class DiscogsArtistSearchRestClientTest implements WithAssertions {
 
       // then
       assertThat(throwable).isInstanceOf(ExternalServiceException.class);
+    }
+
+    private Stream<Arguments> invalidArtistIdProvider() {
+      return Stream.of(
+          Arguments.of((Object) null),
+          Arguments.of("")
+      );
     }
 
     private Stream<Arguments> httpStatusCodeProvider() {

--- a/discogs/src/test/java/rocks/metaldetector/discogs/client/DiscogsDtoFactory.java
+++ b/discogs/src/test/java/rocks/metaldetector/discogs/client/DiscogsDtoFactory.java
@@ -99,7 +99,7 @@ public class DiscogsDtoFactory {
 
     public static DiscogsArtistDto createDefault() {
       return DiscogsArtistDto.builder()
-              .id(666)
+              .id("666")
               .name("Dummy artist")
               .imageUrl("http://image.url")
               .build();

--- a/discogs/src/test/java/rocks/metaldetector/discogs/client/transformer/DiscogsArtistSearchResultContainerTransformerTest.java
+++ b/discogs/src/test/java/rocks/metaldetector/discogs/client/transformer/DiscogsArtistSearchResultContainerTransformerTest.java
@@ -52,7 +52,7 @@ class DiscogsArtistSearchResultContainerTransformerTest implements WithAssertion
       DiscogsArtistSearchResultEntryDto resultEntry = result.getSearchResults().get(index);
       assertThat(resultEntry).isEqualTo(
               DiscogsArtistSearchResultEntryDto.builder()
-                      .id(givenEntry.getId())
+                      .id(String.valueOf(givenEntry.getId()))
                       .name(givenEntry.getTitle())
                       .imageUrl(givenEntry.getThumb())
                       .uri(givenEntry.getUri())

--- a/discogs/src/test/java/rocks/metaldetector/discogs/client/transformer/DiscogsArtistTransformerTest.java
+++ b/discogs/src/test/java/rocks/metaldetector/discogs/client/transformer/DiscogsArtistTransformerTest.java
@@ -32,7 +32,7 @@ class DiscogsArtistTransformerTest implements WithAssertions {
     // then
     assertThat(result).isEqualTo(
             DiscogsArtistDto.builder()
-                            .id(discogsArtist.getId())
+                            .id(String.valueOf(discogsArtist.getId()))
                             .name(discogsArtist.getName())
                             .build()
     );

--- a/discogs/src/test/java/rocks/metaldetector/discogs/facade/DiscogsServiceImplTest.java
+++ b/discogs/src/test/java/rocks/metaldetector/discogs/facade/DiscogsServiceImplTest.java
@@ -16,13 +16,14 @@ import rocks.metaldetector.discogs.client.transformer.DiscogsArtistTransformer;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static rocks.metaldetector.discogs.client.DiscogsDtoFactory.*;
+import static rocks.metaldetector.discogs.client.DiscogsDtoFactory.DiscogsArtistDtoFactory;
+import static rocks.metaldetector.discogs.client.DiscogsDtoFactory.DiscogsArtistFactory;
 import static rocks.metaldetector.discogs.client.DiscogsDtoFactory.DiscogsArtistSearchResultDtoFactory;
 
 @ExtendWith(MockitoExtension.class)
@@ -103,7 +104,7 @@ class DiscogsServiceImplTest implements WithAssertions {
     @DisplayName("Should pass provided artist id to search client")
     void should_pass_arguments() {
       // given
-      var artistId = 123;
+      var artistId = "123";
 
       // when
       underTest.searchArtistById(artistId);
@@ -117,10 +118,10 @@ class DiscogsServiceImplTest implements WithAssertions {
     void should_transform_search_results() {
       // given
       var searchResult = DiscogsArtistFactory.createDefault();
-      doReturn(searchResult).when(searchClient).searchById(anyLong());
+      doReturn(searchResult).when(searchClient).searchById(anyString());
 
       // when
-      underTest.searchArtistById(123);
+      underTest.searchArtistById("123");
 
       // then
       verify(artistTransformer, times(1)).transform(eq(searchResult));
@@ -132,11 +133,11 @@ class DiscogsServiceImplTest implements WithAssertions {
       // given
       var searchResult = DiscogsArtistFactory.createDefault();
       var transformedSearchResult = DiscogsArtistDtoFactory.createDefault();
-      doReturn(searchResult).when(searchClient).searchById(anyLong());
+      doReturn(searchResult).when(searchClient).searchById(anyString());
       doReturn(transformedSearchResult).when(artistTransformer).transform(any());
 
       // when
-      var response = underTest.searchArtistById(123);
+      var response = underTest.searchArtistById("123");
 
       // then
       assertThat(response).isEqualTo(transformedSearchResult);

--- a/persistence/src/main/java/rocks/metaldetector/persistence/config/bootstrap/DefaultDatabaseInitializer.java
+++ b/persistence/src/main/java/rocks/metaldetector/persistence/config/bootstrap/DefaultDatabaseInitializer.java
@@ -15,6 +15,8 @@ import javax.persistence.PersistenceContext;
 import javax.sql.DataSource;
 import java.util.List;
 
+import static rocks.metaldetector.persistence.domain.artist.ArtistSource.DISCOGS;
+
 @Component
 @AllArgsConstructor
 public class DefaultDatabaseInitializer implements ApplicationRunner {
@@ -23,9 +25,9 @@ public class DefaultDatabaseInitializer implements ApplicationRunner {
   private final EntityManager entityManager;
   private final DataSource dataSource;
 
-  private static final long OPETH_DISCOGS_ID = 245797L;
-  private static final long DARKTHRONE_DISCOGS_ID = 252211L;
-  private static final long MAYHEM_DISCOGS_ID = 14092L;
+  private static final String OPETH_DISCOGS_ID = "245797";
+  private static final String DARKTHRONE_DISCOGS_ID = "252211";
+  private static final String MAYHEM_DISCOGS_ID = "14092";
 
   @Override
   @Transactional
@@ -91,9 +93,9 @@ public class DefaultDatabaseInitializer implements ApplicationRunner {
   private void createAndFollowArtists() {
     UserEntity administrator = entityManager.createQuery("select u from users u where u.username = :username", UserEntity.class).setParameter("username", "Administrator").getSingleResult();
 
-    ArtistEntity opeth = new ArtistEntity(OPETH_DISCOGS_ID, "Opeth", "https://img.discogs.com/_ejoULEnb6ub_-_6fUoLW0ZS6C8=/150x150/smart/filters:strip_icc():format(jpeg):mode_rgb():quality(40)/discogs-images/A-245797-1584786531-2513.jpeg.jpg");
-    ArtistEntity darkthrone = new ArtistEntity(DARKTHRONE_DISCOGS_ID, "Darkthrone", "https://img.discogs.com/z6M8OMNo7GXZR9PzQF8WvaqMvXw=/150x150/smart/filters:strip_icc():format(jpeg):mode_rgb():quality(40)/discogs-images/A-252211-1579868454-4269.jpeg.jpg");
-    ArtistEntity mayhem = new ArtistEntity(MAYHEM_DISCOGS_ID, "Mayhem", "https://img.discogs.com/ZtM5dcXMOugk9djxyVN7T6BJm7M=/150x150/smart/filters:strip_icc():format(jpeg):mode_rgb():quality(40)/discogs-images/A-14092-1551425950-6112.jpeg.jpg");
+    ArtistEntity opeth = new ArtistEntity(OPETH_DISCOGS_ID, "Opeth", "https://img.discogs.com/_ejoULEnb6ub_-_6fUoLW0ZS6C8=/150x150/smart/filters:strip_icc():format(jpeg):mode_rgb():quality(40)/discogs-images/A-245797-1584786531-2513.jpeg.jpg", DISCOGS);
+    ArtistEntity darkthrone = new ArtistEntity(DARKTHRONE_DISCOGS_ID, "Darkthrone", "https://img.discogs.com/z6M8OMNo7GXZR9PzQF8WvaqMvXw=/150x150/smart/filters:strip_icc():format(jpeg):mode_rgb():quality(40)/discogs-images/A-252211-1579868454-4269.jpeg.jpg", DISCOGS);
+    ArtistEntity mayhem = new ArtistEntity(MAYHEM_DISCOGS_ID, "Mayhem", "https://img.discogs.com/ZtM5dcXMOugk9djxyVN7T6BJm7M=/150x150/smart/filters:strip_icc():format(jpeg):mode_rgb():quality(40)/discogs-images/A-14092-1551425950-6112.jpeg.jpg", DISCOGS);
 
     entityManager.persist(opeth);
     entityManager.persist(darkthrone);

--- a/persistence/src/main/java/rocks/metaldetector/persistence/domain/artist/ArtistEntity.java
+++ b/persistence/src/main/java/rocks/metaldetector/persistence/domain/artist/ArtistEntity.java
@@ -11,6 +11,8 @@ import rocks.metaldetector.persistence.domain.user.UserEntity;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.ManyToMany;
 import java.util.HashSet;
 import java.util.Set;
@@ -22,8 +24,8 @@ import java.util.Set;
 @EqualsAndHashCode(callSuper = true, exclude = "followedByUsers")
 public class ArtistEntity extends BaseEntity {
 
-  @Column(name = "artist_discogs_id", nullable = false, updatable = false)
-  private long artistDiscogsId;
+  @Column(name = "external_id", nullable = false, updatable = false)
+  private String externalId;
 
   @Column(name = "artist_name", nullable = false, updatable = false)
   @NonNull
@@ -32,13 +34,18 @@ public class ArtistEntity extends BaseEntity {
   @Column(name = "thumb", updatable = false)
   private String thumb;
 
+  @Column(name = "source", nullable = false, updatable = false)
+  @Enumerated(EnumType.STRING)
+  private ArtistSource source;
+
   @ManyToMany(mappedBy = "followedArtists")
   private Set<UserEntity> followedByUsers;
 
-  public ArtistEntity(long artistDiscogsId, String artistName, String thumb) {
-    this.artistDiscogsId = artistDiscogsId;
+  public ArtistEntity(String externalId, String artistName, String thumb, ArtistSource source) {
+    this.externalId = externalId;
     this.artistName = artistName;
     this.thumb = thumb;
+    this.source = source;
     this.followedByUsers = new HashSet<>();
   }
 

--- a/persistence/src/main/java/rocks/metaldetector/persistence/domain/artist/ArtistRepository.java
+++ b/persistence/src/main/java/rocks/metaldetector/persistence/domain/artist/ArtistRepository.java
@@ -3,16 +3,17 @@ package rocks.metaldetector.persistence.domain.artist;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface ArtistRepository extends JpaRepository<ArtistEntity, Long> {
 
-  Optional<ArtistEntity> findByArtistDiscogsId(long artistDiscogsId);
+  Optional<ArtistEntity> findByExternalId(String externalId);
 
-  List<ArtistEntity> findAllByArtistDiscogsIdIn(long... artistDiscogsIds);
+  List<ArtistEntity> findAllByExternalIdIn(Collection<String> externalId);
 
-  boolean existsByArtistDiscogsId(long artistDiscogsId);
+  boolean existsByExternalId(String externalId);
 
 }

--- a/persistence/src/main/java/rocks/metaldetector/persistence/domain/artist/ArtistRepository.java
+++ b/persistence/src/main/java/rocks/metaldetector/persistence/domain/artist/ArtistRepository.java
@@ -12,7 +12,7 @@ public interface ArtistRepository extends JpaRepository<ArtistEntity, Long> {
 
   Optional<ArtistEntity> findByExternalId(String externalId);
 
-  List<ArtistEntity> findAllByExternalIdIn(Collection<String> externalId);
+  List<ArtistEntity> findAllByExternalIdIn(Collection<String> externalIds);
 
   boolean existsByExternalId(String externalId);
 

--- a/persistence/src/main/java/rocks/metaldetector/persistence/domain/artist/ArtistSource.java
+++ b/persistence/src/main/java/rocks/metaldetector/persistence/domain/artist/ArtistSource.java
@@ -1,0 +1,17 @@
+package rocks.metaldetector.persistence.domain.artist;
+
+public enum ArtistSource {
+
+  DISCOGS("Discogs"),
+  SPOTIFY("Spotify");
+
+  private final String value;
+
+  ArtistSource(String value) {
+    this.value = value;
+  }
+
+  public String toDisplayString() {
+    return value;
+  }
+}

--- a/persistence/src/main/java/rocks/metaldetector/persistence/domain/artist/ArtistSource.java
+++ b/persistence/src/main/java/rocks/metaldetector/persistence/domain/artist/ArtistSource.java
@@ -11,7 +11,17 @@ public enum ArtistSource {
     this.value = value;
   }
 
-  public String toDisplayString() {
+  public String getDisplayName() {
     return value;
+  }
+
+  public static ArtistSource getArtistSourceFromString(String source) {
+    if (source.equalsIgnoreCase(DISCOGS.getDisplayName())) {
+      return DISCOGS;
+    }
+    else if (source.equalsIgnoreCase(SPOTIFY.getDisplayName())) {
+      return SPOTIFY;
+    }
+    throw new IllegalArgumentException("Source '" + source + "' not found!");
   }
 }

--- a/persistence/src/main/java/rocks/metaldetector/persistence/domain/user/UserEntity.java
+++ b/persistence/src/main/java/rocks/metaldetector/persistence/domain/user/UserEntity.java
@@ -24,10 +24,10 @@ import javax.persistence.JoinTable;
 import javax.persistence.ManyToMany;
 import javax.persistence.PrePersist;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
-import java.util.ArrayList;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -206,7 +206,7 @@ public class UserEntity extends BaseEntity implements UserDetails {
     artistEntity.removeFollowing(this);
   }
 
-  public boolean isFollowing(long artistId) {
-    return followedArtists.stream().map(ArtistEntity::getArtistDiscogsId).collect(Collectors.toList()).contains(artistId);
+  public boolean isFollowing(String externalId) {
+    return followedArtists.stream().map(ArtistEntity::getExternalId).collect(Collectors.toList()).contains(externalId);
   }
 }

--- a/persistence/src/test/java/rocks/metaldetector/persistence/domain/artist/ArtistEntityFactory.java
+++ b/persistence/src/test/java/rocks/metaldetector/persistence/domain/artist/ArtistEntityFactory.java
@@ -1,8 +1,10 @@
 package rocks.metaldetector.persistence.domain.artist;
 
+import static rocks.metaldetector.persistence.domain.artist.ArtistSource.DISCOGS;
+
 class ArtistEntityFactory {
 
-  static ArtistEntity createArtistEntity(long discogsId, String artistName, String thumb) {
-    return new ArtistEntity(discogsId, artistName, thumb);
+  static ArtistEntity createArtistEntity(String externalId, String artistName) {
+    return new ArtistEntity(externalId, artistName, null, DISCOGS);
   }
 }

--- a/persistence/src/test/java/rocks/metaldetector/persistence/domain/artist/ArtistRepositoryIT.java
+++ b/persistence/src/test/java/rocks/metaldetector/persistence/domain/artist/ArtistRepositoryIT.java
@@ -13,6 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import rocks.metaldetector.persistence.BaseDataJpaTest;
 import rocks.metaldetector.persistence.WithIntegrationTestConfig;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -24,11 +25,11 @@ class ArtistRepositoryIT extends BaseDataJpaTest implements WithAssertions, With
 
   @BeforeEach
   void setUp() {
-    artistRepository.save(ArtistEntityFactory.createArtistEntity(1L, "1", null));
-    artistRepository.save(ArtistEntityFactory.createArtistEntity(2L, "2", null));
-    artistRepository.save(ArtistEntityFactory.createArtistEntity(3L, "3", null));
-    artistRepository.save(ArtistEntityFactory.createArtistEntity(4L, "4", null));
-    artistRepository.save(ArtistEntityFactory.createArtistEntity(5L, "5", null));
+    artistRepository.save(ArtistEntityFactory.createArtistEntity("1", "1"));
+    artistRepository.save(ArtistEntityFactory.createArtistEntity("2", "2"));
+    artistRepository.save(ArtistEntityFactory.createArtistEntity("3", "3"));
+    artistRepository.save(ArtistEntityFactory.createArtistEntity("4", "4"));
+    artistRepository.save(ArtistEntityFactory.createArtistEntity("5", "5"));
   }
 
   @AfterEach
@@ -38,72 +39,72 @@ class ArtistRepositoryIT extends BaseDataJpaTest implements WithAssertions, With
 
   @ParameterizedTest(name = "[{index}] => Entity <{0}>")
   @ValueSource(longs = {1, 2, 3})
-  @DisplayName("findByArtistDiscogsId() finds the correct entity for a given artist id if it exists")
-  void find_by_artist_discogs_id_should_return_correct_entity(long entity) {
-    Optional<ArtistEntity> artistEntityOptional = artistRepository.findByArtistDiscogsId(entity);
+  @DisplayName("findByArtistExternalId() finds the correct entity for a given artist id if it exists")
+  void find_by_artist_external_id_should_return_correct_entity(String entity) {
+    Optional<ArtistEntity> artistEntityOptional = artistRepository.findByExternalId(entity);
 
     assertThat(artistEntityOptional).isPresent();
-    assertThat(artistEntityOptional.get().getArtistDiscogsId()).isEqualTo(entity);
+    assertThat(artistEntityOptional.get().getExternalId()).isEqualTo(entity);
     assertThat(artistEntityOptional.get().getArtistName()).isEqualTo(String.valueOf(entity));
   }
 
   @Test
-  @DisplayName("findByArtistDiscogsId() returns empty optional if given artist does not exist")
-  void find_by_artist_discogs_id_should_return_empty_optional() {
-    Optional<ArtistEntity> artistEntityOptional = artistRepository.findByArtistDiscogsId(0L);
+  @DisplayName("findByArtistExternalId() returns empty optional if given artist does not exist")
+  void find_by_artist_external_id_should_return_empty_optional() {
+    Optional<ArtistEntity> artistEntityOptional = artistRepository.findByExternalId("0");
 
     assertThat(artistEntityOptional).isEmpty();
   }
 
   @ParameterizedTest(name = "[{index}] => Entity <{0}>")
   @ValueSource(longs = {1, 2, 3})
-  @DisplayName("existsByArtistDiscogsId() should return true if artist exists")
-  void exists_by_artist_discogs_id_should_return_true(long entity) {
-    boolean exists = artistRepository.existsByArtistDiscogsId(entity);
+  @DisplayName("existsByArtistExternalId() should return true if artist exists")
+  void exists_by_artist_external_id_should_return_true(String entity) {
+    boolean exists = artistRepository.existsByExternalId(entity);
 
     assertThat(exists).isTrue();
   }
 
   @Test
-  @DisplayName("existsByArtistDiscogsId() should return false if artist does not exist")
-  void exists_by_artist_discogs_id_should_return_false() {
-    boolean exists = artistRepository.existsByArtistDiscogsId(0L);
+  @DisplayName("existsByArtistExternalId() should return false if artist does not exist")
+  void exists_by_artist_external_id_should_return_false() {
+    boolean exists = artistRepository.existsByExternalId("0");
 
     assertThat(exists).isFalse();
   }
 
   @Test
-  @DisplayName("findAllByArtistDiscogsIds() should return correct entities if they exist")
-  void find_all_by_artist_discogs_ids_should_return_correct_entities() {
-    List<ArtistEntity> artistEntities = artistRepository.findAllByArtistDiscogsIdIn(0L, 1L, 2L);
+  @DisplayName("findAllByArtistExternalIds() should return correct entities if they exist")
+  void find_all_by_artist_external_ids_should_return_correct_entities() {
+    List<ArtistEntity> artistEntities = artistRepository.findAllByExternalIdIn(List.of("0", "1", "2"));
 
     assertThat(artistEntities).hasSize(2);
 
     for (int i = 0; i < artistEntities.size(); i++) {
       ArtistEntity entity = artistEntities.get(i);
       assertThat(entity.getArtistName()).isEqualTo(String.valueOf(i + 1));
-      assertThat(entity.getArtistDiscogsId()).isEqualTo(i + 1);
+      assertThat(entity.getExternalId()).isEqualTo(i + 1);
       assertThat(entity.getThumb()).isNull();
     }
   }
 
-  @ParameterizedTest(name = "[{index}] => DiscogsIds <{0}>")
-  @MethodSource("inputProviderDiscogsIds")
-  @DisplayName("findAllByArtistDiscogsIds() should return correct entities if they exist")
-  void find_all_by_artist_discogs_ids_should_return_correct_entities_parametrized(long[] discogsIds) {
-    List<ArtistEntity> artistEntities = artistRepository.findAllByArtistDiscogsIdIn(discogsIds);
+  @ParameterizedTest(name = "[{index}] => ExternalIds <{0}>")
+  @MethodSource("inputProviderExternalIds")
+  @DisplayName("findAllByArtistExternalIds() should return correct entities if they exist")
+  void find_all_by_artist_external_ids_should_return_correct_entities_parametrized(Collection<String> externalIds) {
+    List<ArtistEntity> artistEntities = artistRepository.findAllByExternalIdIn(externalIds);
 
-    assertThat(artistEntities).hasSize(discogsIds.length);
+    assertThat(artistEntities).hasSize(externalIds.size());
 
-    for (int i = 0; i < discogsIds.length; i++) {
+    for (int i = 0; i < externalIds.size(); i++) {
       ArtistEntity entity = artistEntities.get(i);
       assertThat(entity.getArtistName()).isEqualTo(String.valueOf(i + 1));
-      assertThat(entity.getArtistDiscogsId()).isEqualTo(i + 1);
+      assertThat(entity.getExternalId()).isEqualTo(String.valueOf(i + 1));
       assertThat(entity.getThumb()).isNull();
     }
   }
 
-  private static Stream<Arguments> inputProviderDiscogsIds() {
+  private static Stream<Arguments> inputProviderExternalIds() {
     return Stream.of(
         Arguments.of((Object) new long[] {2L, 1L}),
         Arguments.of((Object) new long[] {1L}),

--- a/persistence/src/test/java/rocks/metaldetector/persistence/domain/artist/ArtistRepositoryIT.java
+++ b/persistence/src/test/java/rocks/metaldetector/persistence/domain/artist/ArtistRepositoryIT.java
@@ -8,12 +8,12 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import rocks.metaldetector.persistence.BaseDataJpaTest;
 import rocks.metaldetector.persistence.WithIntegrationTestConfig;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -38,7 +38,7 @@ class ArtistRepositoryIT extends BaseDataJpaTest implements WithAssertions, With
   }
 
   @ParameterizedTest(name = "[{index}] => Entity <{0}>")
-  @ValueSource(longs = {1, 2, 3})
+  @MethodSource("artistIdProvider")
   @DisplayName("findByArtistExternalId() finds the correct entity for a given artist id if it exists")
   void find_by_artist_external_id_should_return_correct_entity(String entity) {
     Optional<ArtistEntity> artistEntityOptional = artistRepository.findByExternalId(entity);
@@ -46,6 +46,14 @@ class ArtistRepositoryIT extends BaseDataJpaTest implements WithAssertions, With
     assertThat(artistEntityOptional).isPresent();
     assertThat(artistEntityOptional.get().getExternalId()).isEqualTo(entity);
     assertThat(artistEntityOptional.get().getArtistName()).isEqualTo(String.valueOf(entity));
+  }
+
+  private static Stream<Arguments> artistIdProvider() {
+    return Stream.of(
+        Arguments.of("1"),
+        Arguments.of("2"),
+        Arguments.of("3")
+    );
   }
 
   @Test
@@ -57,12 +65,20 @@ class ArtistRepositoryIT extends BaseDataJpaTest implements WithAssertions, With
   }
 
   @ParameterizedTest(name = "[{index}] => Entity <{0}>")
-  @ValueSource(longs = {1, 2, 3})
+  @MethodSource("artistIdSource")
   @DisplayName("existsByArtistExternalId() should return true if artist exists")
   void exists_by_artist_external_id_should_return_true(String entity) {
     boolean exists = artistRepository.existsByExternalId(entity);
 
     assertThat(exists).isTrue();
+  }
+
+  private static Stream<Arguments> artistIdSource() {
+    return Stream.of(
+        Arguments.of("1"),
+        Arguments.of("2"),
+        Arguments.of("3")
+    );
   }
 
   @Test
@@ -83,7 +99,7 @@ class ArtistRepositoryIT extends BaseDataJpaTest implements WithAssertions, With
     for (int i = 0; i < artistEntities.size(); i++) {
       ArtistEntity entity = artistEntities.get(i);
       assertThat(entity.getArtistName()).isEqualTo(String.valueOf(i + 1));
-      assertThat(entity.getExternalId()).isEqualTo(i + 1);
+      assertThat(entity.getExternalId()).isEqualTo(String.valueOf(i + 1));
       assertThat(entity.getThumb()).isNull();
     }
   }
@@ -106,9 +122,9 @@ class ArtistRepositoryIT extends BaseDataJpaTest implements WithAssertions, With
 
   private static Stream<Arguments> inputProviderExternalIds() {
     return Stream.of(
-        Arguments.of((Object) new long[] {2L, 1L}),
-        Arguments.of((Object) new long[] {1L}),
-        Arguments.of((Object) new long[] {})
+        Arguments.of(List.of("2", "1")),
+        Arguments.of(List.of("1")),
+        Arguments.of(Collections.emptyList())
     );
   }
 }

--- a/persistence/src/test/java/rocks/metaldetector/persistence/domain/user/ArtistFactory.java
+++ b/persistence/src/test/java/rocks/metaldetector/persistence/domain/user/ArtistFactory.java
@@ -2,9 +2,11 @@ package rocks.metaldetector.persistence.domain.user;
 
 import rocks.metaldetector.persistence.domain.artist.ArtistEntity;
 
+import static rocks.metaldetector.persistence.domain.artist.ArtistSource.DISCOGS;
+
 public class ArtistFactory {
 
-  public static ArtistEntity withDiscogsId(long discogsId) {
-    return new ArtistEntity(discogsId, Long.toString(discogsId), "image url");
+  public static ArtistEntity withExternalId(String externalId) {
+    return new ArtistEntity(externalId, externalId, "image url", DISCOGS);
   }
 }

--- a/persistence/src/test/java/rocks/metaldetector/persistence/domain/user/UserEntityTest.java
+++ b/persistence/src/test/java/rocks/metaldetector/persistence/domain/user/UserEntityTest.java
@@ -212,7 +212,7 @@ class UserEntityTest implements WithAssertions {
     void adding_artist_adds_artist_and_user() {
       // given
       UserEntity user = UserFactory.createUser("user", "email");
-      ArtistEntity artist = ArtistFactory.withDiscogsId(1L);
+      ArtistEntity artist = ArtistFactory.withExternalId("1");
 
       // when
       user.addFollowedArtist(artist);
@@ -227,7 +227,7 @@ class UserEntityTest implements WithAssertions {
     void removing_artist_removes_artist_and_user() {
       // given
       UserEntity user = UserFactory.createUser("user", "email");
-      ArtistEntity artist = ArtistFactory.withDiscogsId(1L);
+      ArtistEntity artist = ArtistFactory.withExternalId("1");
       user.addFollowedArtist(artist);
 
       // when
@@ -243,11 +243,11 @@ class UserEntityTest implements WithAssertions {
     void should_return_true_for_following() {
       // given
       UserEntity user = UserFactory.createUser("user", "email");
-      ArtistEntity artist = ArtistFactory.withDiscogsId(1L);
+      ArtistEntity artist = ArtistFactory.withExternalId("1");
       user.addFollowedArtist(artist);
 
       // when
-      boolean result = user.isFollowing(artist.getArtistDiscogsId());
+      boolean result = user.isFollowing(artist.getExternalId());
 
       // then
       assertThat(result).isTrue();
@@ -258,10 +258,10 @@ class UserEntityTest implements WithAssertions {
     void should_return_false_for_following() {
       // given
       UserEntity user = UserFactory.createUser("user", "email");
-      ArtistEntity artist = ArtistFactory.withDiscogsId(1L);
+      ArtistEntity artist = ArtistFactory.withExternalId("1");
 
       // when
-      boolean result = user.isFollowing(artist.getArtistDiscogsId());
+      boolean result = user.isFollowing(artist.getExternalId());
 
       // then
       assertThat(result).isFalse();

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.2.5.RELEASE</version>
+        <version>2.3.1.RELEASE</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -21,7 +21,7 @@
         <hibernate-validator.version>6.1.2.Final</hibernate-validator.version>
         <validation-api.version>2.0.1.Final</validation-api.version>
         <material-icons.version>0.3.1</material-icons.version>
-        <rest-assured.version>4.3.0</rest-assured.version>
+        <rest-assured.version>4.3.1</rest-assured.version>
         <bootstrap.version>4.5.0</bootstrap.version>
         <datatables.version>1.10.20</datatables.version>
         <thymeleaf-dialect.version>2.4.1</thymeleaf-dialect.version>

--- a/webapp/src/main/java/rocks/metaldetector/service/artist/ArtistDto.java
+++ b/webapp/src/main/java/rocks/metaldetector/service/artist/ArtistDto.java
@@ -11,8 +11,9 @@ import lombok.NoArgsConstructor;
 @Builder
 public class ArtistDto {
 
-  private long discogsId;
+  private String externalId;
   private String artistName;
   private String thumb;
+  private String source;
 
 }

--- a/webapp/src/main/java/rocks/metaldetector/service/artist/ArtistTransformer.java
+++ b/webapp/src/main/java/rocks/metaldetector/service/artist/ArtistTransformer.java
@@ -11,7 +11,7 @@ public class ArtistTransformer {
         .externalId(artistEntity.getExternalId())
         .artistName(artistEntity.getArtistName())
         .thumb(artistEntity.getThumb())
-        .source(artistEntity.getSource().toDisplayString())
+        .source(artistEntity.getSource().getDisplayName())
         .build();
   }
 }

--- a/webapp/src/main/java/rocks/metaldetector/service/artist/ArtistTransformer.java
+++ b/webapp/src/main/java/rocks/metaldetector/service/artist/ArtistTransformer.java
@@ -8,9 +8,10 @@ public class ArtistTransformer {
 
   public ArtistDto transform(ArtistEntity artistEntity) {
     return ArtistDto.builder()
-        .discogsId(artistEntity.getArtistDiscogsId())
+        .externalId(artistEntity.getExternalId())
         .artistName(artistEntity.getArtistName())
         .thumb(artistEntity.getThumb())
+        .source(artistEntity.getSource().toDisplayString())
         .build();
   }
 }

--- a/webapp/src/main/java/rocks/metaldetector/service/artist/ArtistsService.java
+++ b/webapp/src/main/java/rocks/metaldetector/service/artist/ArtistsService.java
@@ -3,14 +3,15 @@ package rocks.metaldetector.service.artist;
 import org.springframework.data.domain.Pageable;
 import rocks.metaldetector.discogs.facade.dto.DiscogsArtistSearchResultDto;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
 public interface ArtistsService {
 
-  Optional<ArtistDto> findArtistByDiscogsId(long discogsId);
-  List<ArtistDto> findAllArtistsByDiscogsIds(long... discogsIds);
-  boolean existsArtistByDiscogsId(long discogsId);
+  Optional<ArtistDto> findArtistByExternalId(String externalId);
+  List<ArtistDto> findAllArtistsByExternalIds(Collection<String> externalIds);
+  boolean existsArtistByExternalId(String externalId);
 
   DiscogsArtistSearchResultDto searchDiscogsByName(String artistQueryString, Pageable pageable);
 

--- a/webapp/src/main/java/rocks/metaldetector/service/artist/ArtistsServiceImpl.java
+++ b/webapp/src/main/java/rocks/metaldetector/service/artist/ArtistsServiceImpl.java
@@ -13,6 +13,7 @@ import rocks.metaldetector.persistence.domain.user.UserRepository;
 import rocks.metaldetector.security.CurrentPublicUserIdSupplier;
 import rocks.metaldetector.support.exceptions.ResourceNotFoundException;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -28,22 +29,22 @@ public class ArtistsServiceImpl implements ArtistsService {
   private final ArtistTransformer artistTransformer;
 
   @Override
-  public Optional<ArtistDto> findArtistByDiscogsId(long discogsId) {
-    return artistRepository.findByArtistDiscogsId(discogsId)
+  public Optional<ArtistDto> findArtistByExternalId(String externalId) {
+    return artistRepository.findByExternalId(externalId)
         .map(artistTransformer::transform);
   }
 
   @Override
-  public List<ArtistDto> findAllArtistsByDiscogsIds(long... discogsIds) {
-    List<ArtistEntity> artistEntities = artistRepository.findAllByArtistDiscogsIdIn(discogsIds);
+  public List<ArtistDto> findAllArtistsByExternalIds(Collection<String> externalIds) {
+    List<ArtistEntity> artistEntities = artistRepository.findAllByExternalIdIn(externalIds);
     return artistEntities.stream()
         .map(artistTransformer::transform)
         .collect(Collectors.toList());
   }
 
   @Override
-  public boolean existsArtistByDiscogsId(long discogsId) {
-    return artistRepository.existsByArtistDiscogsId(discogsId);
+  public boolean existsArtistByExternalId(String externalId) {
+    return artistRepository.existsByExternalId(externalId);
   }
 
   @Override

--- a/webapp/src/main/java/rocks/metaldetector/service/artist/FollowArtistService.java
+++ b/webapp/src/main/java/rocks/metaldetector/service/artist/FollowArtistService.java
@@ -4,7 +4,7 @@ import java.util.List;
 
 public interface FollowArtistService {
 
-  void follow(String externalId);
+  void follow(String externalId, String source);
   void unfollow(String externalId);
   List<ArtistDto> getFollowedArtistsOfCurrentUser();
   List<ArtistDto> getFollowedArtistsOfUser(String publicUserId);

--- a/webapp/src/main/java/rocks/metaldetector/service/artist/FollowArtistService.java
+++ b/webapp/src/main/java/rocks/metaldetector/service/artist/FollowArtistService.java
@@ -4,8 +4,8 @@ import java.util.List;
 
 public interface FollowArtistService {
 
-  void follow(long artistId);
-  void unfollow(long artistId);
+  void follow(String externalId);
+  void unfollow(String externalId);
   List<ArtistDto> getFollowedArtistsOfCurrentUser();
   List<ArtistDto> getFollowedArtistsOfUser(String publicUserId);
 }

--- a/webapp/src/main/java/rocks/metaldetector/service/artist/FollowArtistServiceImpl.java
+++ b/webapp/src/main/java/rocks/metaldetector/service/artist/FollowArtistServiceImpl.java
@@ -8,6 +8,7 @@ import rocks.metaldetector.discogs.facade.DiscogsService;
 import rocks.metaldetector.discogs.facade.dto.DiscogsArtistDto;
 import rocks.metaldetector.persistence.domain.artist.ArtistEntity;
 import rocks.metaldetector.persistence.domain.artist.ArtistRepository;
+import rocks.metaldetector.persistence.domain.artist.ArtistSource;
 import rocks.metaldetector.persistence.domain.user.UserEntity;
 import rocks.metaldetector.persistence.domain.user.UserRepository;
 import rocks.metaldetector.security.CurrentPublicUserIdSupplier;
@@ -15,8 +16,6 @@ import rocks.metaldetector.support.exceptions.ResourceNotFoundException;
 
 import java.util.List;
 import java.util.stream.Collectors;
-
-import static rocks.metaldetector.persistence.domain.artist.ArtistSource.DISCOGS;
 
 @AllArgsConstructor
 @Service
@@ -31,8 +30,8 @@ public class FollowArtistServiceImpl implements FollowArtistService {
 
   @Override
   @Transactional
-  public void follow(String externalId) {
-    ArtistEntity artist = saveAndFetchArtist(externalId);
+  public void follow(String externalId, String source) {
+    ArtistEntity artist = saveAndFetchArtist(externalId, source);
     UserEntity user = currentUser();
     user.addFollowedArtist(artist);
     userRepository.save(user);
@@ -63,14 +62,14 @@ public class FollowArtistServiceImpl implements FollowArtistService {
     return user.getFollowedArtists().stream().map(artistTransformer::transform).collect(Collectors.toUnmodifiableList());
   }
 
-  private ArtistEntity saveAndFetchArtist(String externalId) {
+  private ArtistEntity saveAndFetchArtist(String externalId, String source) {
     if (artistRepository.existsByExternalId(externalId)) {
       //noinspection OptionalGetWithoutIsPresent: call is safe due to prior existsBy check
       return artistRepository.findByExternalId(externalId).get();
     }
 
     DiscogsArtistDto artist = discogsService.searchArtistById(externalId);
-    ArtistEntity artistEntity = new ArtistEntity(artist.getId(), artist.getName(), artist.getImageUrl(), DISCOGS); // ToDo NilsD: how can I get source here? -> send from frontend
+    ArtistEntity artistEntity = new ArtistEntity(artist.getId(), artist.getName(), artist.getImageUrl(), ArtistSource.getArtistSourceFromString(source));
     return artistRepository.save(artistEntity);
   }
 

--- a/webapp/src/main/java/rocks/metaldetector/web/controller/rest/ArtistsRestController.java
+++ b/webapp/src/main/java/rocks/metaldetector/web/controller/rest/ArtistsRestController.java
@@ -32,15 +32,15 @@ public class ArtistsRestController {
     return ResponseEntity.ok(result);
   }
 
-  @PostMapping(path = Endpoints.Rest.FOLLOW + "/{discogsId}")
-  public ResponseEntity<Void> handleFollow(@PathVariable long discogsId) {
-    followArtistService.follow(discogsId);
+  @PostMapping(path = Endpoints.Rest.FOLLOW + "/{externalId}")
+  public ResponseEntity<Void> handleFollow(@PathVariable String externalId) {
+    followArtistService.follow(externalId);
     return ResponseEntity.ok().build();
   }
 
-  @PostMapping(path = Endpoints.Rest.UNFOLLOW + "/{discogsId}")
-  public ResponseEntity<Void> handleUnfollow(@PathVariable long discogsId) {
-    followArtistService.unfollow(discogsId);
+  @PostMapping(path = Endpoints.Rest.UNFOLLOW + "/{externalId}")
+  public ResponseEntity<Void> handleUnfollow(@PathVariable String externalId) {
+    followArtistService.unfollow(externalId);
     return ResponseEntity.ok().build();
   }
 }

--- a/webapp/src/main/java/rocks/metaldetector/web/controller/rest/ArtistsRestController.java
+++ b/webapp/src/main/java/rocks/metaldetector/web/controller/rest/ArtistsRestController.java
@@ -33,8 +33,11 @@ public class ArtistsRestController {
   }
 
   @PostMapping(path = Endpoints.Rest.FOLLOW + "/{externalId}")
-  public ResponseEntity<Void> handleFollow(@PathVariable String externalId) {
-    followArtistService.follow(externalId);
+  public ResponseEntity<Void> handleFollow(@PathVariable String externalId, @RequestParam(value = "source") String source) {
+    if (source.isEmpty()) {
+      throw new IllegalArgumentException("Artist source must be set");
+    }
+    followArtistService.follow(externalId, source);
     return ResponseEntity.ok().build();
   }
 

--- a/webapp/src/main/resources/static/js/follow-artists.js
+++ b/webapp/src/main/resources/static/js/follow-artists.js
@@ -1,6 +1,6 @@
 /**
  * Send ajax request to follow an artist
- * @param artistId    Artist's discogs id
+ * @param artistId    Artist's external id
  * @param artistName  The name of the artist
  * @returns {boolean}
  */
@@ -23,7 +23,7 @@ function followArtist(artistId, artistName) {
 
 /**
  * Send ajax request to unfollow an artist
- * @param artistId    Artist's discogs id
+ * @param artistId    Artist's external id
  * @param artistName  The name of the artist
  * @returns {boolean}
  */

--- a/webapp/src/main/resources/static/js/follow-artists.js
+++ b/webapp/src/main/resources/static/js/follow-artists.js
@@ -7,7 +7,7 @@
 function followArtist(artistId, artistName) {
     $.ajax({
         method: "POST",
-        url: "/rest/v1/artists/follow/" + artistId,
+        url: "/rest/v1/artists/follow/" + artistId + "?source=Discogs",
         success: function() {
             const icon = $(`#${artistId}`);
             icon.text("favorite");

--- a/webapp/src/main/resources/static/js/my-artists.js
+++ b/webapp/src/main/resources/static/js/my-artists.js
@@ -74,7 +74,7 @@ function createMyArtistsCards(myArtists){
     cardBody.append(breakElement);
 
     const followArtistButtonElement = createFollowArtistButton(artist.artistName,
-      artist.discogsId, true);
+      artist.externalId, true);
     cardBody.append(followArtistButtonElement);
 
     document.getElementById('myArtistsContainer').append(card);

--- a/webapp/src/main/resources/static/js/search.js
+++ b/webapp/src/main/resources/static/js/search.js
@@ -136,14 +136,14 @@ function createHeadlineText(query, searchResponse) {
 /**
  * Appends the top search result to the DOM.
  * @param topSearchResult           The top search result
- * @param topSearchResult.id        The discogs id of the artist
+ * @param topSearchResult.id        The external id of the artist
  * @param topSearchResult.name      The name of the artist
  * @param topSearchResult.imageUrl  The url of the artist thumbnail
  * @param topSearchResult.followed  True if the current user already follow this artist, false otherwise
  */
 function appendTopSearchResult(topSearchResult) {
     const topResultHtml = renderTopResultHtml({
-        discogsId: topSearchResult.id,
+        externalId: topSearchResult.id,
         name: topSearchResult.name,
         imageUrl: topSearchResult.imageUrl,
         followedByUser: topSearchResult.followed,
@@ -178,7 +178,7 @@ function appendOtherSearchResults(searchResults, currentPage) {
         }
 
         rowWrapper.append(renderOtherSearchResultsHtml({
-            discogsId: result.id,
+            externalId: result.id,
             name: result.name,
             imageUrl: result.imageUrl,
             followedByUser: result.followed
@@ -233,7 +233,7 @@ function renderUnknownErrorOccurred() {
 
 /**
  * Renders the HTML for the top search result.
- * @param artistInfo.discogsId          The discogs id of the artist
+ * @param artistInfo.externalId         The external id of the artist
  * @param artistInfo.name               The name of the artist
  * @param artistInfo.imageUrl           The url of the artist thumbnail
  * @param artistInfo.followedByUser     True if the current user already follow this artist, false otherwise
@@ -256,7 +256,7 @@ function renderTopResultHtml(artistInfo) {
                                     <p class="h4 card-title mt-3">${artistInfo.name}</p>
                                 </div>
                                 <div class="col-md-auto">
-                                    ${renderFollowOrUnfollowIcon(artistInfo.discogsId, artistInfo.name, artistInfo.followedByUser)}
+                                    ${renderFollowOrUnfollowIcon(artistInfo.externalId, artistInfo.name, artistInfo.followedByUser)}
                                 </div>
                             </div>
                             <div class="row">
@@ -275,7 +275,7 @@ function renderTopResultHtml(artistInfo) {
 
 /**
  * Renders the HTML for the other search results.
- * @param artistInfo.discogsId          The discogs id of the artist
+ * @param artistInfo.externalId         The external id of the artist
  * @param artistInfo.name               The name of the artist
  * @param artistInfo.imageUrl           The url of the artist thumbnail
  * @param artistInfo.followedByUser     True if the current user already follow this artist, false otherwise
@@ -295,7 +295,7 @@ function renderOtherSearchResultsHtml(artistInfo) {
                                 <p class="h5 card-title mt-2">${artistInfo.name}</p>
                             </div>
                             <div class="col-md-auto">
-                                ${renderFollowOrUnfollowIcon(artistInfo.discogsId, artistInfo.name, artistInfo.followedByUser)}
+                                ${renderFollowOrUnfollowIcon(artistInfo.externalId, artistInfo.name, artistInfo.followedByUser)}
                             </div>
                         </div>
                     </div>
@@ -306,10 +306,10 @@ function renderOtherSearchResultsHtml(artistInfo) {
 
 /**
  * Renders the HTML for the follow or unfollow icon.
- * @param artistId        The discogs id of the artist
- * @param artistName      The name of the artist
+ * @param artistId        The artist's external id
+ * @param artistName      The artist's name
  * @param followedByUser  True if the current user already follow this artist, false otherwise
- * @returns {string}  The whole HTML for follow or unfollow icon
+ * @returns {string}      The whole HTML for follow or unfollow icon
  */
 function renderFollowOrUnfollowIcon(artistId, artistName, followedByUser) {
     artistName = artistName.replace(new RegExp("'", "g"), "");

--- a/webapp/src/main/resources/static/js/util.js
+++ b/webapp/src/main/resources/static/js/util.js
@@ -59,7 +59,7 @@ function createNoResultsMessage(text) {
 /**
  * Builds the onclick function
  * @param artistName    Artist to follow
- * @param artistId      Artist's discogs id
+ * @param artistId      Artist's external id
  * @param isFollowed    true if user follows given artist
  * @param button        Button that was clicked
  * @returns {Function}
@@ -72,8 +72,8 @@ function createOnClickFunctionFollowArtist(artistName, artistId, isFollowed, but
 
 /**
  * Builds an HTML button to follow an artist
- * @param artistName    The artists name
- * @param artistId      The artists discogs id
+ * @param artistName    The artist's name
+ * @param artistId      The artist's external id
  * @param isFollowed    The information if the artist is already followed
  * @returns {HTMLButtonElement}
  */

--- a/webapp/src/test/java/rocks/metaldetector/service/artist/ArtistEntityFactory.java
+++ b/webapp/src/test/java/rocks/metaldetector/service/artist/ArtistEntityFactory.java
@@ -2,9 +2,11 @@ package rocks.metaldetector.service.artist;
 
 import rocks.metaldetector.persistence.domain.artist.ArtistEntity;
 
+import static rocks.metaldetector.persistence.domain.artist.ArtistSource.DISCOGS;
+
 public class ArtistEntityFactory {
 
-  public static ArtistEntity withDiscogsId(long discogsId) {
-    return new ArtistEntity(discogsId, Long.toString(discogsId), "image url");
+  public static ArtistEntity withExternalId(String externalId) {
+    return new ArtistEntity(externalId, externalId, "image url", DISCOGS);
   }
 }

--- a/webapp/src/test/java/rocks/metaldetector/service/artist/ArtistTransformerTest.java
+++ b/webapp/src/test/java/rocks/metaldetector/service/artist/ArtistTransformerTest.java
@@ -22,6 +22,6 @@ class ArtistTransformerTest implements WithAssertions {
     assertThat(result.getExternalId()).isEqualTo(artistEntity.getExternalId());
     assertThat(result.getArtistName()).isEqualTo(artistEntity.getArtistName());
     assertThat(result.getThumb()).isEqualTo(artistEntity.getThumb());
-    assertThat(result.getSource()).isEqualTo(artistEntity.getSource().toDisplayString());
+    assertThat(result.getSource()).isEqualTo(artistEntity.getSource().getDisplayName());
   }
 }

--- a/webapp/src/test/java/rocks/metaldetector/service/artist/ArtistTransformerTest.java
+++ b/webapp/src/test/java/rocks/metaldetector/service/artist/ArtistTransformerTest.java
@@ -13,14 +13,15 @@ class ArtistTransformerTest implements WithAssertions {
   @DisplayName("Should transform ArtistEntity to ArtistDto")
   void should_transform_entity_to_dto() {
     // given
-    ArtistEntity artistEntity = ArtistEntityFactory.withDiscogsId(1L);
+    ArtistEntity artistEntity = ArtistEntityFactory.withExternalId("1");
 
     // when
     ArtistDto result = underTest.transform(artistEntity);
 
     // then
-    assertThat(result.getDiscogsId()).isEqualTo(artistEntity.getArtistDiscogsId());
+    assertThat(result.getExternalId()).isEqualTo(artistEntity.getExternalId());
     assertThat(result.getArtistName()).isEqualTo(artistEntity.getArtistName());
     assertThat(result.getThumb()).isEqualTo(artistEntity.getThumb());
+    assertThat(result.getSource()).isEqualTo(artistEntity.getSource().toDisplayString());
   }
 }

--- a/webapp/src/test/java/rocks/metaldetector/service/artist/ArtistsServiceImplTest.java
+++ b/webapp/src/test/java/rocks/metaldetector/service/artist/ArtistsServiceImplTest.java
@@ -75,7 +75,7 @@ class ArtistsServiceImplTest implements WithAssertions {
   @BeforeEach
   void setUp() {
     artistEntity = new ArtistEntity(EXTERNAL_ID, ARTIST_NAME, null, DISCOGS);
-    artistDto = new ArtistDto(EXTERNAL_ID, ARTIST_NAME, null, "DISCOGS");
+    artistDto = new ArtistDto(EXTERNAL_ID, ARTIST_NAME, null, "Discogs");
   }
 
   @Test
@@ -245,8 +245,8 @@ class ArtistsServiceImplTest implements WithAssertions {
     doReturn(UUID.randomUUID().toString()).when(currentPublicUserIdSupplier).get();
     doReturn(Optional.of(userEntityMock)).when(userRepository).findByPublicId(anyString());
     when(userEntityMock.isFollowing(anyString())).then(invocationOnMock -> {
-      long artistId = invocationOnMock.getArgument(0);
-      return artistId == 1 || artistId == 3;
+      String artistId = invocationOnMock.getArgument(0);
+      return artistId.equals("1") || artistId.equals("3");
     });
     doReturn(discogsSearchResults).when(discogsService).searchArtistByName(any(), anyInt(), anyInt());
 

--- a/webapp/src/test/java/rocks/metaldetector/service/artist/ArtistsServiceImplTest.java
+++ b/webapp/src/test/java/rocks/metaldetector/service/artist/ArtistsServiceImplTest.java
@@ -27,7 +27,6 @@ import java.util.Optional;
 import java.util.UUID;
 
 import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doReturn;
@@ -36,11 +35,12 @@ import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static rocks.metaldetector.persistence.domain.artist.ArtistSource.DISCOGS;
 
 @ExtendWith(MockitoExtension.class)
 class ArtistsServiceImplTest implements WithAssertions {
 
-  private static final long DISCOGS_ID = 1L;
+  private static final String EXTERNAL_ID = "1";
   private static final String ARTIST_NAME = "A";
 
   @Mock
@@ -74,19 +74,19 @@ class ArtistsServiceImplTest implements WithAssertions {
 
   @BeforeEach
   void setUp() {
-    artistEntity = new ArtistEntity(DISCOGS_ID, ARTIST_NAME, null);
-    artistDto = new ArtistDto(DISCOGS_ID, ARTIST_NAME, null);
+    artistEntity = new ArtistEntity(EXTERNAL_ID, ARTIST_NAME, null, DISCOGS);
+    artistDto = new ArtistDto(EXTERNAL_ID, ARTIST_NAME, null, "DISCOGS");
   }
 
   @Test
-  @DisplayName("findArtistByDiscogsId() should return the correct artist if it exists")
+  @DisplayName("findArtistByExternalId() should return the correct artist if it exists")
   void find_by_discogs_id_should_return_correct_artist() {
     // given
-    when(artistRepository.findByArtistDiscogsId(anyLong())).thenReturn(Optional.of(artistEntity));
+    when(artistRepository.findByExternalId(anyString())).thenReturn(Optional.of(artistEntity));
     when(artistTransformer.transform(any())).thenReturn(ArtistDtoFactory.createDefault());
 
     // when
-    Optional<ArtistDto> artistOptional = underTest.findArtistByDiscogsId(DISCOGS_ID);
+    Optional<ArtistDto> artistOptional = underTest.findArtistByExternalId(EXTERNAL_ID);
 
     // then
     assertThat(artistOptional).isPresent();
@@ -94,50 +94,50 @@ class ArtistsServiceImplTest implements WithAssertions {
   }
 
   @Test
-  @DisplayName("findArtistByDiscogsId() should call artist repository")
+  @DisplayName("findArtistByExternalId() should call artist repository")
   void find_by_discogs_id_should_call_artist_repository() {
     // given
-    when(artistRepository.findByArtistDiscogsId(anyLong())).thenReturn(Optional.of(artistEntity));
+    when(artistRepository.findByExternalId(anyString())).thenReturn(Optional.of(artistEntity));
 
     // when
-    underTest.findArtistByDiscogsId(DISCOGS_ID);
+    underTest.findArtistByExternalId(EXTERNAL_ID);
 
     // then
-    verify(artistRepository, times(1)).findByArtistDiscogsId(DISCOGS_ID);
+    verify(artistRepository, times(1)).findByExternalId(EXTERNAL_ID);
   }
 
   @Test
-  @DisplayName("findArtistByDiscogsId() should call artist dto transformer")
+  @DisplayName("findArtistByExternalId() should call artist dto transformer")
   void find_by_discogs_id_should_call_artist_dto_transformer() {
     // given
-    when(artistRepository.findByArtistDiscogsId(anyLong())).thenReturn(Optional.of(artistEntity));
+    when(artistRepository.findByExternalId(anyString())).thenReturn(Optional.of(artistEntity));
 
     // when
-    underTest.findArtistByDiscogsId(DISCOGS_ID);
+    underTest.findArtistByExternalId(EXTERNAL_ID);
 
     // then
     verify(artistTransformer, times(1)).transform(artistEntity);
   }
 
   @Test
-  @DisplayName("findArtistByDiscogsId() should return an empty optional if artist does not exist")
+  @DisplayName("findArtistByExternalId() should return an empty optional if artist does not exist")
   void find_by_discogs_id_should_return_empty_optional() {
     // when
-    Optional<ArtistDto> artistOptional = underTest.findArtistByDiscogsId(DISCOGS_ID);
+    Optional<ArtistDto> artistOptional = underTest.findArtistByExternalId(EXTERNAL_ID);
 
     // then
     assertThat(artistOptional).isEmpty();
   }
 
   @Test
-  @DisplayName("findAllByArtistDiscogsIdIn() should return all given entities that exist")
+  @DisplayName("findAllByArtistExternalIdIn() should return all given entities that exist")
   void find_all_by_discogs_ids_should_return_all_entities_that_exist() {
     // given
-    when(artistRepository.findAllByArtistDiscogsIdIn(anyLong(), anyLong())).thenReturn(List.of(artistEntity));
+    when(artistRepository.findAllByExternalIdIn(any())).thenReturn(List.of(artistEntity));
     when(artistTransformer.transform(any())).thenReturn(ArtistDtoFactory.createDefault());
 
     // when
-    List<ArtistDto> artists = underTest.findAllArtistsByDiscogsIds(DISCOGS_ID, 0L);
+    List<ArtistDto> artists = underTest.findAllArtistsByExternalIds(List.of(EXTERNAL_ID, "0"));
 
     // then
     assertThat(artists).hasSize(1);
@@ -145,62 +145,62 @@ class ArtistsServiceImplTest implements WithAssertions {
   }
 
   @Test
-  @DisplayName("findAllByArtistDiscogsIdIn() should call artist repository")
+  @DisplayName("findAllByArtistExternalIdIn() should call artist repository")
   void find_all_by_discogs_ids_should_call_artist_repository() {
     // when
-    underTest.findAllArtistsByDiscogsIds(DISCOGS_ID, 0L);
+    underTest.findAllArtistsByExternalIds(List.of(EXTERNAL_ID, "0"));
 
     // then
-    verify(artistRepository, times(1)).findAllByArtistDiscogsIdIn(DISCOGS_ID, 0L);
+    verify(artistRepository, times(1)).findAllByExternalIdIn(List.of(EXTERNAL_ID, "0"));
   }
 
   @Test
-  @DisplayName("findAllByArtistDiscogsIdIn() should call artist dto transformer")
+  @DisplayName("findAllByArtistExternalIdIn() should call artist dto transformer")
   void find_all_by_discogs_ids_should_call_artist_dto_transformer() {
     // given
-    when(artistRepository.findAllByArtistDiscogsIdIn(anyLong(), anyLong())).thenReturn(List.of(artistEntity));
+    when(artistRepository.findAllByExternalIdIn(any())).thenReturn(List.of(artistEntity));
 
     // when
-    underTest.findAllArtistsByDiscogsIds(anyLong(), anyLong());
+    underTest.findAllArtistsByExternalIds(List.of(EXTERNAL_ID, "0"));
 
     // then
     verify(artistTransformer, times(1)).transform(artistEntity);
   }
 
   @Test
-  @DisplayName("existsArtistByDiscogsId() should return true if given entity exists")
+  @DisplayName("existsArtistByExternalId() should return true if given entity exists")
   void exists_by_discogs_id_should_return_true() {
     // given
-    when(artistRepository.existsByArtistDiscogsId(anyLong())).thenReturn(true);
+    when(artistRepository.existsByExternalId(any())).thenReturn(true);
 
     // when
-    boolean exists = underTest.existsArtistByDiscogsId(DISCOGS_ID);
+    boolean exists = underTest.existsArtistByExternalId(EXTERNAL_ID);
 
     // then
     assertThat(exists).isTrue();
   }
 
   @Test
-  @DisplayName("existsArtistByDiscogsId() should return false if given entity does not exist")
+  @DisplayName("existsArtistByExternalId() should return false if given entity does not exist")
   void exists_by_discogs_id_should_return_false() {
     // given
-    when(artistRepository.existsByArtistDiscogsId(anyLong())).thenReturn(false);
+    when(artistRepository.existsByExternalId(any())).thenReturn(false);
 
     // when
-    boolean exists = underTest.existsArtistByDiscogsId(DISCOGS_ID);
+    boolean exists = underTest.existsArtistByExternalId(EXTERNAL_ID);
 
     // then
     assertThat(exists).isFalse();
   }
 
   @Test
-  @DisplayName("existsArtistByDiscogsId() should call artist repository")
+  @DisplayName("existsArtistByExternalId() should call artist repository")
   void exists_by_discogs_id_should_call_artist_repository() {
     // when
-    underTest.existsArtistByDiscogsId(DISCOGS_ID);
+    underTest.existsArtistByExternalId(EXTERNAL_ID);
 
     // then
-    verify(artistRepository, times(1)).existsByArtistDiscogsId(DISCOGS_ID);
+    verify(artistRepository, times(1)).existsByExternalId(EXTERNAL_ID);
   }
 
   @Test
@@ -241,10 +241,10 @@ class ArtistsServiceImplTest implements WithAssertions {
   void searchDiscogsByName_should_mark_already_followed_artists() {
     // given
     var discogsSearchResults = DiscogsArtistSearchResultDtoFactory.createDefault();
-    discogsSearchResults.setSearchResults(createListOfSearchResultEntries(1, 2, 3));
+    discogsSearchResults.setSearchResults(createListOfSearchResultEntries(List.of("1", "2", "3")));
     doReturn(UUID.randomUUID().toString()).when(currentPublicUserIdSupplier).get();
     doReturn(Optional.of(userEntityMock)).when(userRepository).findByPublicId(anyString());
-    when(userEntityMock.isFollowing(anyLong())).then(invocationOnMock -> {
+    when(userEntityMock.isFollowing(anyString())).then(invocationOnMock -> {
       long artistId = invocationOnMock.getArgument(0);
       return artistId == 1 || artistId == 3;
     });
@@ -296,11 +296,11 @@ class ArtistsServiceImplTest implements WithAssertions {
     assertThat(throwable).hasMessageContaining(userId);
   }
 
-  private List<DiscogsArtistSearchResultEntryDto> createListOfSearchResultEntries(long... artistIds) {
+  private List<DiscogsArtistSearchResultEntryDto> createListOfSearchResultEntries(List<String> externalIds) {
     return List.of(
-        DiscogsArtistSearchResultEntryDtoFactory.withId(artistIds[0]),
-        DiscogsArtistSearchResultEntryDtoFactory.withId(artistIds[1]),
-        DiscogsArtistSearchResultEntryDtoFactory.withId(artistIds[2])
+        DiscogsArtistSearchResultEntryDtoFactory.withId(externalIds.get(0)),
+        DiscogsArtistSearchResultEntryDtoFactory.withId(externalIds.get(1)),
+        DiscogsArtistSearchResultEntryDtoFactory.withId(externalIds.get(2))
     );
   }
 }

--- a/webapp/src/test/java/rocks/metaldetector/service/artist/FollowArtistServiceImplTest.java
+++ b/webapp/src/test/java/rocks/metaldetector/service/artist/FollowArtistServiceImplTest.java
@@ -174,7 +174,7 @@ class FollowArtistServiceImplTest implements WithAssertions {
     assertThat(artistEntity.getArtistName()).isEqualTo(discogsArtist.getName());
     assertThat(artistEntity.getExternalId()).isEqualTo(discogsArtist.getId());
     assertThat(artistEntity.getThumb()).isEqualTo(discogsArtist.getImageUrl());
-    assertThat(artistEntity.getSource()).isEqualTo(ARTIST_SOURCE);
+    assertThat(artistEntity.getSource().getDisplayName()).isEqualTo(ARTIST_SOURCE);
   }
 
   @Test

--- a/webapp/src/test/java/rocks/metaldetector/service/artist/FollowArtistServiceImplTest.java
+++ b/webapp/src/test/java/rocks/metaldetector/service/artist/FollowArtistServiceImplTest.java
@@ -39,6 +39,7 @@ import static rocks.metaldetector.testutil.DtoFactory.DiscogsArtistDtoFactory;
 class FollowArtistServiceImplTest implements WithAssertions {
 
   private static final String EXTERNAL_ID = "252211";
+  private static final String ARTIST_SOURCE = "Discogs";
 
   @Mock
   private UserRepository userRepository;
@@ -76,7 +77,7 @@ class FollowArtistServiceImplTest implements WithAssertions {
     when(userRepository.findByPublicId(anyString())).thenReturn(Optional.of(userEntity));
 
     // when
-    underTest.follow(EXTERNAL_ID);
+    underTest.follow(EXTERNAL_ID, ARTIST_SOURCE);
 
     // then
     InOrder inOrderVerifier = inOrder(artistRepository);
@@ -95,7 +96,7 @@ class FollowArtistServiceImplTest implements WithAssertions {
     when(userRepository.findByPublicId(anyString())).thenReturn(Optional.of(userEntity));
 
     // when
-    underTest.follow(EXTERNAL_ID);
+    underTest.follow(EXTERNAL_ID, ARTIST_SOURCE);
 
     // then
     verify(currentPublicUserIdSupplier, times(1)).get();
@@ -113,7 +114,7 @@ class FollowArtistServiceImplTest implements WithAssertions {
     when(userRepository.findByPublicId(anyString())).thenThrow(new ResourceNotFoundException(userId));
 
     // when
-    Throwable throwable = catchThrowable(() -> underTest.follow("1"));
+    Throwable throwable = catchThrowable(() -> underTest.follow("1", ARTIST_SOURCE));
 
     // then
     assertThat(throwable).isInstanceOf(ResourceNotFoundException.class);
@@ -130,7 +131,7 @@ class FollowArtistServiceImplTest implements WithAssertions {
     when(userRepository.findByPublicId(anyString())).thenReturn(Optional.of(userEntity));
 
     // when
-    underTest.follow(EXTERNAL_ID);
+    underTest.follow(EXTERNAL_ID, ARTIST_SOURCE);
 
     // then
     verify(discogsService, times(1)).searchArtistById(EXTERNAL_ID);
@@ -146,7 +147,7 @@ class FollowArtistServiceImplTest implements WithAssertions {
     when(userRepository.findByPublicId(anyString())).thenReturn(Optional.of(userEntity));
 
     // when
-    underTest.follow(EXTERNAL_ID);
+    underTest.follow(EXTERNAL_ID, ARTIST_SOURCE);
 
     // then
     verifyNoInteractions(discogsService);
@@ -164,7 +165,7 @@ class FollowArtistServiceImplTest implements WithAssertions {
     when(artistRepository.save(any())).thenReturn(ArtistEntityFactory.withExternalId(EXTERNAL_ID));
 
     // when
-    underTest.follow(EXTERNAL_ID);
+    underTest.follow(EXTERNAL_ID, ARTIST_SOURCE);
 
     // then
     verify(artistRepository, times(1)).save(argumentCaptor.capture());
@@ -173,6 +174,7 @@ class FollowArtistServiceImplTest implements WithAssertions {
     assertThat(artistEntity.getArtistName()).isEqualTo(discogsArtist.getName());
     assertThat(artistEntity.getExternalId()).isEqualTo(discogsArtist.getId());
     assertThat(artistEntity.getThumb()).isEqualTo(discogsArtist.getImageUrl());
+    assertThat(artistEntity.getSource()).isEqualTo(ARTIST_SOURCE);
   }
 
   @Test
@@ -186,7 +188,7 @@ class FollowArtistServiceImplTest implements WithAssertions {
     when(userRepository.findByPublicId(anyString())).thenReturn(Optional.of(userEntity));
 
     // when
-    underTest.follow(EXTERNAL_ID);
+    underTest.follow(EXTERNAL_ID, ARTIST_SOURCE);
 
     // then
     verify(userEntity, times(1)).addFollowedArtist(artist);

--- a/webapp/src/test/java/rocks/metaldetector/service/artist/FollowArtistServiceImplTest.java
+++ b/webapp/src/test/java/rocks/metaldetector/service/artist/FollowArtistServiceImplTest.java
@@ -26,7 +26,6 @@ import java.util.Set;
 import java.util.UUID;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.reset;
@@ -39,7 +38,7 @@ import static rocks.metaldetector.testutil.DtoFactory.DiscogsArtistDtoFactory;
 @ExtendWith(MockitoExtension.class)
 class FollowArtistServiceImplTest implements WithAssertions {
 
-  private static final long ARTIST_ID = 252211L;
+  private static final String EXTERNAL_ID = "252211";
 
   @Mock
   private UserRepository userRepository;
@@ -71,18 +70,18 @@ class FollowArtistServiceImplTest implements WithAssertions {
   @DisplayName("Artist is fetched from repository if it already exists on follow")
   void follow_should_get_artist() {
     // given
-    when(artistRepository.existsByArtistDiscogsId(anyLong())).thenReturn(true);
-    when(artistRepository.findByArtistDiscogsId(anyLong())).thenReturn(Optional.of(ArtistEntityFactory.withDiscogsId(ARTIST_ID)));
+    when(artistRepository.existsByExternalId(anyString())).thenReturn(true);
+    when(artistRepository.findByExternalId(anyString())).thenReturn(Optional.of(ArtistEntityFactory.withExternalId(EXTERNAL_ID)));
     when(currentPublicUserIdSupplier.get()).thenReturn(UUID.randomUUID().toString());
     when(userRepository.findByPublicId(anyString())).thenReturn(Optional.of(userEntity));
 
     // when
-    underTest.follow(ARTIST_ID);
+    underTest.follow(EXTERNAL_ID);
 
     // then
     InOrder inOrderVerifier = inOrder(artistRepository);
-    inOrderVerifier.verify(artistRepository, times(1)).existsByArtistDiscogsId(ARTIST_ID);
-    inOrderVerifier.verify(artistRepository, times(1)).findByArtistDiscogsId(ARTIST_ID);
+    inOrderVerifier.verify(artistRepository, times(1)).existsByExternalId(EXTERNAL_ID);
+    inOrderVerifier.verify(artistRepository, times(1)).findByExternalId(EXTERNAL_ID);
   }
 
   @Test
@@ -90,13 +89,13 @@ class FollowArtistServiceImplTest implements WithAssertions {
   void follow_should_get_current_user() {
     // given
     String publicUserId = UUID.randomUUID().toString();
-    when(artistRepository.existsByArtistDiscogsId(anyLong())).thenReturn(true);
-    when(artistRepository.findByArtistDiscogsId(anyLong())).thenReturn(Optional.of(ArtistEntityFactory.withDiscogsId(ARTIST_ID)));
+    when(artistRepository.existsByExternalId(anyString())).thenReturn(true);
+    when(artistRepository.findByExternalId(anyString())).thenReturn(Optional.of(ArtistEntityFactory.withExternalId(EXTERNAL_ID)));
     when(currentPublicUserIdSupplier.get()).thenReturn(publicUserId);
     when(userRepository.findByPublicId(anyString())).thenReturn(Optional.of(userEntity));
 
     // when
-    underTest.follow(ARTIST_ID);
+    underTest.follow(EXTERNAL_ID);
 
     // then
     verify(currentPublicUserIdSupplier, times(1)).get();
@@ -108,13 +107,13 @@ class FollowArtistServiceImplTest implements WithAssertions {
   void follow_should_throw_exception() {
     // given
     String userId = "publicUserId";
-    when(artistRepository.existsByArtistDiscogsId(anyLong())).thenReturn(true);
-    when(artistRepository.findByArtistDiscogsId(anyLong())).thenReturn(Optional.of(ArtistEntityFactory.withDiscogsId(ARTIST_ID)));
+    when(artistRepository.existsByExternalId(anyString())).thenReturn(true);
+    when(artistRepository.findByExternalId(anyString())).thenReturn(Optional.of(ArtistEntityFactory.withExternalId(EXTERNAL_ID)));
     when(currentPublicUserIdSupplier.get()).thenReturn(userId);
     when(userRepository.findByPublicId(anyString())).thenThrow(new ResourceNotFoundException(userId));
 
     // when
-    Throwable throwable = catchThrowable(() -> underTest.follow(1L));
+    Throwable throwable = catchThrowable(() -> underTest.follow("1"));
 
     // then
     assertThat(throwable).isInstanceOf(ResourceNotFoundException.class);
@@ -125,29 +124,29 @@ class FollowArtistServiceImplTest implements WithAssertions {
   @DisplayName("Artist is searched on discogs if it does not yet exist on follow")
   void follow_should_search_discogs() {
     // given
-    when(discogsService.searchArtistById(anyLong())).thenReturn(DiscogsArtistDtoFactory.createDefault());
+    when(discogsService.searchArtistById(anyString())).thenReturn(DiscogsArtistDtoFactory.createDefault());
     when(currentPublicUserIdSupplier.get()).thenReturn(UUID.randomUUID().toString());
-    when(artistRepository.save(any())).thenReturn(ArtistEntityFactory.withDiscogsId(ARTIST_ID));
+    when(artistRepository.save(any())).thenReturn(ArtistEntityFactory.withExternalId(EXTERNAL_ID));
     when(userRepository.findByPublicId(anyString())).thenReturn(Optional.of(userEntity));
 
     // when
-    underTest.follow(ARTIST_ID);
+    underTest.follow(EXTERNAL_ID);
 
     // then
-    verify(discogsService, times(1)).searchArtistById(ARTIST_ID);
+    verify(discogsService, times(1)).searchArtistById(EXTERNAL_ID);
   }
 
   @Test
   @DisplayName("Discogs is not searched if artist already exists")
   void follow_should_not_search_discogs() {
     // given
-    when(artistRepository.existsByArtistDiscogsId(anyLong())).thenReturn(true);
-    when(artistRepository.findByArtistDiscogsId(anyLong())).thenReturn(Optional.of(ArtistEntityFactory.withDiscogsId(ARTIST_ID)));
+    when(artistRepository.existsByExternalId(anyString())).thenReturn(true);
+    when(artistRepository.findByExternalId(anyString())).thenReturn(Optional.of(ArtistEntityFactory.withExternalId(EXTERNAL_ID)));
     when(currentPublicUserIdSupplier.get()).thenReturn(UUID.randomUUID().toString());
     when(userRepository.findByPublicId(anyString())).thenReturn(Optional.of(userEntity));
 
     // when
-    underTest.follow(ARTIST_ID);
+    underTest.follow(EXTERNAL_ID);
 
     // then
     verifyNoInteractions(discogsService);
@@ -159,20 +158,20 @@ class FollowArtistServiceImplTest implements WithAssertions {
     // given
     ArgumentCaptor<ArtistEntity> argumentCaptor = ArgumentCaptor.forClass(ArtistEntity.class);
     DiscogsArtistDto discogsArtist = DiscogsArtistDtoFactory.createDefault();
-    when(discogsService.searchArtistById(anyLong())).thenReturn(discogsArtist);
+    when(discogsService.searchArtistById(anyString())).thenReturn(discogsArtist);
     when(currentPublicUserIdSupplier.get()).thenReturn(UUID.randomUUID().toString());
     when(userRepository.findByPublicId(anyString())).thenReturn(Optional.of(userEntity));
-    when(artistRepository.save(any())).thenReturn(ArtistEntityFactory.withDiscogsId(ARTIST_ID));
+    when(artistRepository.save(any())).thenReturn(ArtistEntityFactory.withExternalId(EXTERNAL_ID));
 
     // when
-    underTest.follow(ARTIST_ID);
+    underTest.follow(EXTERNAL_ID);
 
     // then
     verify(artistRepository, times(1)).save(argumentCaptor.capture());
 
     ArtistEntity artistEntity = argumentCaptor.getValue();
     assertThat(artistEntity.getArtistName()).isEqualTo(discogsArtist.getName());
-    assertThat(artistEntity.getArtistDiscogsId()).isEqualTo(discogsArtist.getId());
+    assertThat(artistEntity.getExternalId()).isEqualTo(discogsArtist.getId());
     assertThat(artistEntity.getThumb()).isEqualTo(discogsArtist.getImageUrl());
   }
 
@@ -180,14 +179,14 @@ class FollowArtistServiceImplTest implements WithAssertions {
   @DisplayName("User is updated with artist on follow")
   void follow_should_add_artist_to_user() {
     // given
-    ArtistEntity artist = ArtistEntityFactory.withDiscogsId(ARTIST_ID);
-    when(artistRepository.existsByArtistDiscogsId(anyLong())).thenReturn(true);
-    when(artistRepository.findByArtistDiscogsId(anyLong())).thenReturn(Optional.of(artist));
+    ArtistEntity artist = ArtistEntityFactory.withExternalId(EXTERNAL_ID);
+    when(artistRepository.existsByExternalId(anyString())).thenReturn(true);
+    when(artistRepository.findByExternalId(anyString())).thenReturn(Optional.of(artist));
     when(currentPublicUserIdSupplier.get()).thenReturn(UUID.randomUUID().toString());
     when(userRepository.findByPublicId(anyString())).thenReturn(Optional.of(userEntity));
 
     // when
-    underTest.follow(ARTIST_ID);
+    underTest.follow(EXTERNAL_ID);
 
     // then
     verify(userEntity, times(1)).addFollowedArtist(artist);
@@ -198,15 +197,15 @@ class FollowArtistServiceImplTest implements WithAssertions {
   @DisplayName("Artist is fetched from repository on unfollow")
   void unfollow_should_fetch_artist_from_repository() {
     // given
-    when(artistRepository.findByArtistDiscogsId(anyLong())).thenReturn(Optional.of(ArtistEntityFactory.withDiscogsId(ARTIST_ID)));
+    when(artistRepository.findByExternalId(anyString())).thenReturn(Optional.of(ArtistEntityFactory.withExternalId(EXTERNAL_ID)));
     when(currentPublicUserIdSupplier.get()).thenReturn(UUID.randomUUID().toString());
     when(userRepository.findByPublicId(anyString())).thenReturn(Optional.of(userEntity));
 
     // when
-    underTest.unfollow(ARTIST_ID);
+    underTest.unfollow(EXTERNAL_ID);
 
     // then
-    verify(artistRepository, times(1)).findByArtistDiscogsId(ARTIST_ID);
+    verify(artistRepository, times(1)).findByExternalId(EXTERNAL_ID);
   }
 
   @Test
@@ -214,12 +213,12 @@ class FollowArtistServiceImplTest implements WithAssertions {
   void unfollow_should_fetch_current_user() {
     // given
     String publicUserId = UUID.randomUUID().toString();
-    when(artistRepository.findByArtistDiscogsId(anyLong())).thenReturn(Optional.of(ArtistEntityFactory.withDiscogsId(ARTIST_ID)));
+    when(artistRepository.findByExternalId(anyString())).thenReturn(Optional.of(ArtistEntityFactory.withExternalId(EXTERNAL_ID)));
     when(currentPublicUserIdSupplier.get()).thenReturn(publicUserId);
     when(userRepository.findByPublicId(anyString())).thenReturn(Optional.of(userEntity));
 
     // when
-    underTest.unfollow(ARTIST_ID);
+    underTest.unfollow(EXTERNAL_ID);
 
     // then
     verify(currentPublicUserIdSupplier, times(1)).get();
@@ -231,12 +230,12 @@ class FollowArtistServiceImplTest implements WithAssertions {
   void unfollow_should_throw_exception() {
     // given
     String userId = "publicUserId";
-    when(artistRepository.findByArtistDiscogsId(anyLong())).thenReturn(Optional.of(ArtistEntityFactory.withDiscogsId(ARTIST_ID)));
+    when(artistRepository.findByExternalId(anyString())).thenReturn(Optional.of(ArtistEntityFactory.withExternalId(EXTERNAL_ID)));
     when(currentPublicUserIdSupplier.get()).thenReturn(userId);
     when(userRepository.findByPublicId(anyString())).thenThrow(new ResourceNotFoundException(userId));
 
     // when
-    Throwable throwable = catchThrowable(() -> underTest.unfollow(1L));
+    Throwable throwable = catchThrowable(() -> underTest.unfollow("1"));
 
     // then
     assertThat(throwable).isInstanceOf(ResourceNotFoundException.class);
@@ -248,14 +247,14 @@ class FollowArtistServiceImplTest implements WithAssertions {
   void unfollow_should_remove_artist_from_user() {
     // given
     ArgumentCaptor<UserEntity> argumentCaptor = ArgumentCaptor.forClass(UserEntity.class);
-    ArtistEntity artist = ArtistEntityFactory.withDiscogsId(ARTIST_ID);
+    ArtistEntity artist = ArtistEntityFactory.withExternalId(EXTERNAL_ID);
     userEntity.addFollowedArtist(artist);
-    when(artistRepository.findByArtistDiscogsId(anyLong())).thenReturn(Optional.of(artist));
+    when(artistRepository.findByExternalId(anyString())).thenReturn(Optional.of(artist));
     when(currentPublicUserIdSupplier.get()).thenReturn(UUID.randomUUID().toString());
     when(userRepository.findByPublicId(anyString())).thenReturn(Optional.of(userEntity));
 
     // when
-    underTest.unfollow(ARTIST_ID);
+    underTest.unfollow(EXTERNAL_ID);
 
     // then
     verify(userRepository, times(1)).save(argumentCaptor.capture());
@@ -300,8 +299,8 @@ class FollowArtistServiceImplTest implements WithAssertions {
   @DisplayName("Getting followed artists calls artist transformer for every artist")
   void get_followed_should_call_artist_transformer() {
     // given
-    ArtistEntity artist1 = ArtistEntityFactory.withDiscogsId(1L);
-    ArtistEntity artist2 = ArtistEntityFactory.withDiscogsId(2L);
+    ArtistEntity artist1 = ArtistEntityFactory.withExternalId("1");
+    ArtistEntity artist2 = ArtistEntityFactory.withExternalId("2");
     when(currentPublicUserIdSupplier.get()).thenReturn("userId");
     when(userRepository.findByPublicId(anyString())).thenReturn(Optional.of(userEntity));
     when(userEntity.getFollowedArtists()).thenReturn(Set.of(artist1, artist2));
@@ -319,7 +318,7 @@ class FollowArtistServiceImplTest implements WithAssertions {
   @DisplayName("Getting followed artists returns list of artist dtos")
   void get_followed_should_return_artist_dtos() {
     // given
-    ArtistEntity artistEntity = ArtistEntityFactory.withDiscogsId(1L);
+    ArtistEntity artistEntity = ArtistEntityFactory.withExternalId("1");
     ArtistDto artistDto = ArtistDtoFactory.withName("Darkthrone");
     when(currentPublicUserIdSupplier.get()).thenReturn("userId");
     when(userRepository.findByPublicId(anyString())).thenReturn(Optional.of(userEntity));

--- a/webapp/src/test/java/rocks/metaldetector/testutil/DtoFactory.java
+++ b/webapp/src/test/java/rocks/metaldetector/testutil/DtoFactory.java
@@ -193,6 +193,7 @@ public class DtoFactory {
       return ArtistDto.builder()
               .artistName(name)
               .externalId("1")
+              .source("Discogs")
               .build();
     }
   }

--- a/webapp/src/test/java/rocks/metaldetector/testutil/DtoFactory.java
+++ b/webapp/src/test/java/rocks/metaldetector/testutil/DtoFactory.java
@@ -20,7 +20,7 @@ import java.util.UUID;
 
 public class DtoFactory {
 
-  private static final long DISCOGS_ID = 252211L;
+  private static final String EXTERNAL_ID = "252211";
   private static final String ARTIST_NAME = "Darkthrone";
 
   public static class UserDtoFactory {
@@ -137,12 +137,12 @@ public class DtoFactory {
   public static class DiscogsArtistSearchResultEntryDtoFactory {
 
     static DiscogsArtistSearchResultEntryDto createDefault() {
-      return withId(DISCOGS_ID);
+      return withId(EXTERNAL_ID);
     }
 
-    public static DiscogsArtistSearchResultEntryDto withId(long discogsId) {
+    public static DiscogsArtistSearchResultEntryDto withId(String externalId) {
       return DiscogsArtistSearchResultEntryDto.builder()
-              .id(discogsId)
+              .id(externalId)
               .name(ARTIST_NAME)
               .build();
     }
@@ -152,7 +152,7 @@ public class DtoFactory {
 
     public static DiscogsArtistDto createDefault() {
       return DiscogsArtistDto.builder()
-              .id(DISCOGS_ID)
+              .id(EXTERNAL_ID)
               .name(ARTIST_NAME)
               .build();
     }
@@ -192,7 +192,7 @@ public class DtoFactory {
     public static ArtistDto withName(String name) {
       return ArtistDto.builder()
               .artistName(name)
-              .discogsId(1L)
+              .externalId("1")
               .build();
     }
   }

--- a/webapp/src/test/java/rocks/metaldetector/web/RestAssuredMockMvcUtils.java
+++ b/webapp/src/test/java/rocks/metaldetector/web/RestAssuredMockMvcUtils.java
@@ -66,11 +66,21 @@ public class RestAssuredMockMvcUtils {
 
   public ValidatableMockMvcResponse doPost(String pathSegment) {
     return given()
-        .contentType(ContentType.JSON)
-        .accept(ContentType.JSON)
-        .when()
-        .post(requestUri + pathSegment)
-        .then();
+            .contentType(ContentType.JSON)
+            .accept(ContentType.JSON)
+          .when()
+            .post(requestUri + pathSegment)
+          .then();
+  }
+
+  public ValidatableMockMvcResponse doPost(String pathSegment, Map<String, Object> requestParams) {
+    return given()
+            .contentType(ContentType.JSON)
+            .accept(ContentType.JSON)
+            .params(requestParams)
+          .when()
+            .post(requestUri + pathSegment)
+          .then();
   }
 
   public ValidatableMockMvcResponse doPost(Object request) {
@@ -80,7 +90,7 @@ public class RestAssuredMockMvcUtils {
             .body(request)
           .when()
             .post(requestUri)
-        .then();
+          .then();
   }
 
   public ValidatableMockMvcResponse doPost(Map<String, String> params, ContentType contentType) {

--- a/webapp/src/test/java/rocks/metaldetector/web/controller/rest/ArtistsRestControllerTest.java
+++ b/webapp/src/test/java/rocks/metaldetector/web/controller/rest/ArtistsRestControllerTest.java
@@ -34,7 +34,7 @@ import static org.springframework.security.test.web.servlet.setup.SecurityMockMv
 @ExtendWith(MockitoExtension.class)
 class ArtistsRestControllerTest implements WithAssertions {
 
-  private static final long VALID_ARTIST_ID = 252211L;
+  private static final String VALID_EXTERNLA_ID = "252211";
   private static final String VALID_SEARCH_REQUEST = "Darkthrone";
 
   @Mock
@@ -151,7 +151,7 @@ class ArtistsRestControllerTest implements WithAssertions {
     @DisplayName("Should return 200 when following an artist")
     void handle_follow_return_200() {
       // when
-      var validatableResponse = followArtistRestAssuredUtils.doPost("/" + VALID_ARTIST_ID);
+      var validatableResponse = followArtistRestAssuredUtils.doPost("/" + VALID_EXTERNLA_ID);
 
       // then
       validatableResponse.statusCode(HttpStatus.OK.value());
@@ -161,17 +161,17 @@ class ArtistsRestControllerTest implements WithAssertions {
     @DisplayName("Should call follow artist service when following an artist")
     void handle_follow_call_follow_artist_service() {
       // when
-      followArtistRestAssuredUtils.doPost("/" + VALID_ARTIST_ID);
+      followArtistRestAssuredUtils.doPost("/" + VALID_EXTERNLA_ID);
 
       // then
-      verify(followArtistService, times(1)).follow(VALID_ARTIST_ID);
+      verify(followArtistService, times(1)).follow(VALID_EXTERNLA_ID);
     }
 
     @Test
     @DisplayName("Should return 200 when unfollowing an artist")
     void handle_unfollow_return_200() {
       // when
-      var validatableResponse = unfollowArtistRestAssuredUtils.doPost("/" + VALID_ARTIST_ID);
+      var validatableResponse = unfollowArtistRestAssuredUtils.doPost("/" + VALID_EXTERNLA_ID);
 
       // then
       validatableResponse.statusCode(HttpStatus.OK.value());
@@ -181,10 +181,10 @@ class ArtistsRestControllerTest implements WithAssertions {
     @DisplayName("Should call follow artist service when unfollowing an artist")
     void handle_unfollow_call_follow_artist_service() {
       // when
-      unfollowArtistRestAssuredUtils.doPost("/" + VALID_ARTIST_ID);
+      unfollowArtistRestAssuredUtils.doPost("/" + VALID_EXTERNLA_ID);
 
       // then
-      verify(followArtistService, times(1)).unfollow(VALID_ARTIST_ID);
+      verify(followArtistService, times(1)).unfollow(VALID_EXTERNLA_ID);
     }
   }
 }

--- a/webapp/src/test/java/rocks/metaldetector/web/controller/rest/ArtistsRestControllerTest.java
+++ b/webapp/src/test/java/rocks/metaldetector/web/controller/rest/ArtistsRestControllerTest.java
@@ -153,8 +153,12 @@ class ArtistsRestControllerTest implements WithAssertions {
     @Test
     @DisplayName("Should return 200 when following an artist")
     void handle_follow_return_200() {
+      // given
+      Map<String, Object> requestParams = new HashMap<>();
+      requestParams.put("source", VALID_SOURCE);
+
       // when
-      var validatableResponse = followArtistRestAssuredUtils.doPost("/" + VALID_EXTERNLA_ID);
+      var validatableResponse = followArtistRestAssuredUtils.doPost("/" + VALID_EXTERNLA_ID, requestParams);
 
       // then
       validatableResponse.statusCode(HttpStatus.OK.value());

--- a/webapp/src/test/java/rocks/metaldetector/web/controller/rest/ArtistsRestControllerTest.java
+++ b/webapp/src/test/java/rocks/metaldetector/web/controller/rest/ArtistsRestControllerTest.java
@@ -35,7 +35,7 @@ import static org.springframework.security.test.web.servlet.setup.SecurityMockMv
 @ExtendWith(MockitoExtension.class)
 class ArtistsRestControllerTest implements WithAssertions {
 
-  private static final String VALID_EXTERNLA_ID = "252211";
+  private static final String VALID_EXTERNAL_ID = "252211";
   private static final String VALID_SOURCE = "Discogs";
   private static final String VALID_SEARCH_REQUEST = "Darkthrone";
 
@@ -158,7 +158,7 @@ class ArtistsRestControllerTest implements WithAssertions {
       requestParams.put("source", VALID_SOURCE);
 
       // when
-      var validatableResponse = followArtistRestAssuredUtils.doPost("/" + VALID_EXTERNLA_ID, requestParams);
+      var validatableResponse = followArtistRestAssuredUtils.doPost("/" + VALID_EXTERNAL_ID, requestParams);
 
       // then
       validatableResponse.statusCode(HttpStatus.OK.value());
@@ -172,10 +172,10 @@ class ArtistsRestControllerTest implements WithAssertions {
       requestParams.put("source", VALID_SOURCE);
 
       // when
-      followArtistRestAssuredUtils.doPost("/" + VALID_EXTERNLA_ID, requestParams);
+      followArtistRestAssuredUtils.doPost("/" + VALID_EXTERNAL_ID, requestParams);
 
       // then
-      verify(followArtistService, times(1)).follow(VALID_EXTERNLA_ID, VALID_SOURCE);
+      verify(followArtistService, times(1)).follow(VALID_EXTERNAL_ID, VALID_SOURCE);
     }
 
     @Test
@@ -186,7 +186,7 @@ class ArtistsRestControllerTest implements WithAssertions {
       requestParams.put("source", "");
 
       // when
-      var result = followArtistRestAssuredUtils.doPost("/" + VALID_EXTERNLA_ID, requestParams);
+      var result = followArtistRestAssuredUtils.doPost("/" + VALID_EXTERNAL_ID, requestParams);
 
       // then
       result.status(HttpStatus.BAD_REQUEST);
@@ -196,7 +196,7 @@ class ArtistsRestControllerTest implements WithAssertions {
     @DisplayName("Should return 200 when unfollowing an artist")
     void handle_unfollow_return_200() {
       // when
-      var validatableResponse = unfollowArtistRestAssuredUtils.doPost("/" + VALID_EXTERNLA_ID);
+      var validatableResponse = unfollowArtistRestAssuredUtils.doPost("/" + VALID_EXTERNAL_ID);
 
       // then
       validatableResponse.statusCode(HttpStatus.OK.value());
@@ -206,10 +206,10 @@ class ArtistsRestControllerTest implements WithAssertions {
     @DisplayName("Should call follow artist service when unfollowing an artist")
     void handle_unfollow_call_follow_artist_service() {
       // when
-      unfollowArtistRestAssuredUtils.doPost("/" + VALID_EXTERNLA_ID);
+      unfollowArtistRestAssuredUtils.doPost("/" + VALID_EXTERNAL_ID);
 
       // then
-      verify(followArtistService, times(1)).unfollow(VALID_EXTERNLA_ID);
+      verify(followArtistService, times(1)).unfollow(VALID_EXTERNAL_ID);
     }
   }
 }

--- a/webapp/src/test/resources/integrationtest.properties
+++ b/webapp/src/test/resources/integrationtest.properties
@@ -14,3 +14,5 @@ security.remember-me-secret=test-remember-me-secret
 spring.mail.host=test-mail-host
 spring.mail.username=test-mail-username
 spring.mail.password=test-mail-password
+
+server.port=8080


### PR DESCRIPTION
In this PR the `externalId` for artists is introduced together with a source from where the artists are fetched.
The externalId replaces the discogsId and will also be used for Spotify. The source value is currently hardcoded to discogs. Setting its dynamically will be done in the spotify PR as there would be unnecessary conflicts otherwise.