### PR TITLE
fix frontpage layout bug

### DIFF
--- a/webapp/src/main/resources/static/css/frontend.css
+++ b/webapp/src/main/resources/static/css/frontend.css
@@ -56,7 +56,6 @@ footer .list-inline-item {
 
 .homepage-card-img {
     height: 18rem;
-    width: 18rem;
     object-fit: cover;
     border-bottom: 1px solid #404040;
 }

--- a/webapp/src/main/resources/static/css/frontend.navbar.css
+++ b/webapp/src/main/resources/static/css/frontend.navbar.css
@@ -1,5 +1,5 @@
 nav .container {
-    min-width: 1440px;
+    max-width: 1440px;
 }
 
 .navbar {


### PR DESCRIPTION
The images no longer run out of the frame and when the browser is minimized, the search bar contracts so that no horizontal scrollbar appears.

The pictures are still not 100% perfect, especially when you switch to the mobile view. But this is a separate issue when we take care of a mobile-optimized layout. For the browser, that's fine for now.