### PR TITLE
Retry cover downloads

### DIFF
--- a/butler/src/main/java/rocks/metaldetector/butler/client/ReleaseButlerRestClient.java
+++ b/butler/src/main/java/rocks/metaldetector/butler/client/ReleaseButlerRestClient.java
@@ -12,6 +12,8 @@ public interface ReleaseButlerRestClient {
 
   void createImportJob();
 
+  void createRetryCoverDownloadJob();
+
   List<ButlerImportJob> queryImportJobResults();
 
 }

--- a/butler/src/main/java/rocks/metaldetector/butler/client/ReleaseButlerRestClientImpl.java
+++ b/butler/src/main/java/rocks/metaldetector/butler/client/ReleaseButlerRestClientImpl.java
@@ -55,7 +55,7 @@ public class ReleaseButlerRestClientImpl implements ReleaseButlerRestClient {
 
   @Override
   public void createRetryCoverDownloadJob() {
-    ResponseEntity<Void> responseEntity = releaseButlerRestTemplate.postForEntity(butlerConfig.getCoverUrl(), null, Void.class);
+    ResponseEntity<Void> responseEntity = releaseButlerRestTemplate.postForEntity(butlerConfig.getRetryCoverDownloadUrl(), null, Void.class);
     if (!responseEntity.getStatusCode().is2xxSuccessful()) {
       throw new ExternalServiceException("Could not retry cover download (Response code: " + responseEntity.getStatusCode() + ")");
     }

--- a/butler/src/main/java/rocks/metaldetector/butler/client/ReleaseButlerRestClientImpl.java
+++ b/butler/src/main/java/rocks/metaldetector/butler/client/ReleaseButlerRestClientImpl.java
@@ -54,6 +54,14 @@ public class ReleaseButlerRestClientImpl implements ReleaseButlerRestClient {
   }
 
   @Override
+  public void createRetryCoverDownloadJob() {
+    ResponseEntity<Void> responseEntity = releaseButlerRestTemplate.postForEntity(butlerConfig.getCoverUrl(), null, Void.class);
+    if (!responseEntity.getStatusCode().is2xxSuccessful()) {
+      throw new ExternalServiceException("Could not retry cover download (Response code: " + responseEntity.getStatusCode() + ")");
+    }
+  }
+
+  @Override
   public List<ButlerImportJob> queryImportJobResults() {
     ResponseEntity<ButlerImportResponse> responseEntity = releaseButlerRestTemplate.getForEntity(
             butlerConfig.getImportUrl(),

--- a/butler/src/main/java/rocks/metaldetector/butler/client/ReleaseButlerRestClientMock.java
+++ b/butler/src/main/java/rocks/metaldetector/butler/client/ReleaseButlerRestClientMock.java
@@ -46,6 +46,11 @@ public class ReleaseButlerRestClientMock implements ReleaseButlerRestClient {
   }
 
   @Override
+  public void createRetryCoverDownloadJob() {
+    log.info("Covers successfully downloaded!");
+  }
+
+  @Override
   public List<ButlerImportJob> queryImportJobResults() {
     return List.of(
         new ButlerImportJob(650, 630, LocalDateTime.of(2020, 7, 28, 13, 37, 16), LocalDateTime.of(2020, 7, 28, 13, 39, 51), "Metal Achives"),

--- a/butler/src/main/java/rocks/metaldetector/butler/config/ButlerConfig.java
+++ b/butler/src/main/java/rocks/metaldetector/butler/config/ButlerConfig.java
@@ -15,5 +15,6 @@ public class ButlerConfig {
   private String accessToken;
   private String unpaginatedReleasesUrl;
   private String importUrl;
+  private String coverUrl;
 
 }

--- a/butler/src/main/java/rocks/metaldetector/butler/config/ButlerConfig.java
+++ b/butler/src/main/java/rocks/metaldetector/butler/config/ButlerConfig.java
@@ -15,6 +15,6 @@ public class ButlerConfig {
   private String accessToken;
   private String unpaginatedReleasesUrl;
   private String importUrl;
-  private String coverUrl;
+  private String retryCoverDownloadUrl;
 
 }

--- a/butler/src/main/java/rocks/metaldetector/butler/facade/ReleaseService.java
+++ b/butler/src/main/java/rocks/metaldetector/butler/facade/ReleaseService.java
@@ -12,5 +12,7 @@ public interface ReleaseService {
 
   void createImportJob();
 
+  void createRetryCoverDownloadJob();
+
   List<ImportJobResultDto> queryImportJobResults();
 }

--- a/butler/src/main/java/rocks/metaldetector/butler/facade/ReleaseServiceImpl.java
+++ b/butler/src/main/java/rocks/metaldetector/butler/facade/ReleaseServiceImpl.java
@@ -38,6 +38,11 @@ public class ReleaseServiceImpl implements ReleaseService {
   }
 
   @Override
+  public void createRetryCoverDownloadJob() {
+    butlerClient.createRetryCoverDownloadJob();
+  }
+
+  @Override
   public List<ImportJobResultDto> queryImportJobResults() {
     List<ButlerImportJob> importJobResponses = butlerClient.queryImportJobResults();
     return importJobResponses.stream().map(importJobResponseTransformer::transform).collect(Collectors.toList());

--- a/butler/src/test/java/rocks/metaldetector/butler/client/ReleaseButlerRestClientImplTest.java
+++ b/butler/src/test/java/rocks/metaldetector/butler/client/ReleaseButlerRestClientImplTest.java
@@ -223,7 +223,7 @@ class ReleaseButlerRestClientImplTest implements WithAssertions {
     void test_post_on_cover_url() {
       // given
       var butlerUrl = "cover-url";
-      doReturn(butlerUrl).when(butlerConfig).getCoverUrl();
+      doReturn(butlerUrl).when(butlerConfig).getRetryCoverDownloadUrl();
       doReturn(ResponseEntity.ok().build()).when(restTemplate).postForEntity(anyString(), any(), any());
 
       // when
@@ -237,14 +237,14 @@ class ReleaseButlerRestClientImplTest implements WithAssertions {
     @DisplayName("Cover url of the butler config is used")
     void test_cover_url_from_butler_config_is_used() {
       // given
-      doReturn("cover-url").when(butlerConfig).getCoverUrl();
+      doReturn("cover-url").when(butlerConfig).getRetryCoverDownloadUrl();
       doReturn(ResponseEntity.ok().build()).when(restTemplate).postForEntity(anyString(), any(), eq(Void.class));
 
       // when
       underTest.createRetryCoverDownloadJob();
 
       // then
-      verify(butlerConfig, times(1)).getCoverUrl();
+      verify(butlerConfig, times(1)).getRetryCoverDownloadUrl();
     }
 
     @ParameterizedTest(name = "If the status is {0}, an ExternalServiceException is thrown")
@@ -252,7 +252,7 @@ class ReleaseButlerRestClientImplTest implements WithAssertions {
     @DisplayName("If the status code is not OK on cover download job, an ExternalServiceException is thrown")
     void test_cover_download_job_exception_if_status_is_not_ok(HttpStatus httpStatus) {
       // given
-      doReturn("cover-url").when(butlerConfig).getCoverUrl();
+      doReturn("cover-url").when(butlerConfig).getRetryCoverDownloadUrl();
       doReturn(ResponseEntity.status(httpStatus).build()).when(restTemplate).postForEntity(anyString(), any(), eq(Void.class));
 
       // when

--- a/butler/src/test/java/rocks/metaldetector/butler/client/ReleaseButlerRestClientMockTest.java
+++ b/butler/src/test/java/rocks/metaldetector/butler/client/ReleaseButlerRestClientMockTest.java
@@ -74,6 +74,13 @@ class ReleaseButlerRestClientMockTest implements WithAssertions {
   }
 
   @Test
+  @DisplayName("Should do nothing on create cover download job")
+  void should_do_nothing_on_create_cover_download_job() {
+    // when
+    underTest.createRetryCoverDownloadJob();
+  }
+
+  @Test
   @DisplayName("Should return mocked import job responses")
   void should_return_mocked_import_job_responses() {
     // when

--- a/butler/src/test/java/rocks/metaldetector/butler/facade/ReleaseServiceImplTest.java
+++ b/butler/src/test/java/rocks/metaldetector/butler/facade/ReleaseServiceImplTest.java
@@ -164,4 +164,14 @@ class ReleaseServiceImplTest implements WithAssertions {
             ImportJobResultDtoFactory.createDefault()
     ));
   }
+
+  @Test
+  @DisplayName("Creating an cover download job should call butler client")
+  void create_cover_download_job_should_call_butler_client() {
+    // when
+    underTest.createRetryCoverDownloadJob();
+
+    // then
+    verify(butlerClient, times(1)).createRetryCoverDownloadJob();
+  }
 }

--- a/webapp/src/main/java/rocks/metaldetector/config/constants/Endpoints.java
+++ b/webapp/src/main/java/rocks/metaldetector/config/constants/Endpoints.java
@@ -44,7 +44,7 @@ public class Endpoints {
     public static final String MY_ARTISTS      = "/rest/v1/my-artists";
     public static final String QUERY_RELEASES  = "/rest/v1/releases";
     public static final String IMPORT_JOB      = "/rest/v1/releases/import";
-    public static final String COVER_JOB       = "/rest/v1/releases/cover";
+    public static final String COVER_JOB       = "/rest/v1/releases/cover-reload";
     public static final String SEARCH          = "/search";
     public static final String FOLLOW          = "/follow";
     public static final String UNFOLLOW        = "/unfollow";

--- a/webapp/src/main/java/rocks/metaldetector/config/constants/Endpoints.java
+++ b/webapp/src/main/java/rocks/metaldetector/config/constants/Endpoints.java
@@ -44,6 +44,7 @@ public class Endpoints {
     public static final String MY_ARTISTS      = "/rest/v1/my-artists";
     public static final String QUERY_RELEASES  = "/rest/v1/releases";
     public static final String IMPORT_JOB      = "/rest/v1/releases/import";
+    public static final String COVER_JOB       = "/rest/v1/releases/cover";
     public static final String SEARCH          = "/search";
     public static final String FOLLOW          = "/follow";
     public static final String UNFOLLOW        = "/unfollow";

--- a/webapp/src/main/java/rocks/metaldetector/web/controller/rest/ReleasesRestController.java
+++ b/webapp/src/main/java/rocks/metaldetector/web/controller/rest/ReleasesRestController.java
@@ -51,4 +51,11 @@ public class ReleasesRestController {
     List<ImportJobResultDto> response = releaseService.queryImportJobResults();
     return ResponseEntity.ok(response);
   }
+
+  @PostMapping(path = Endpoints.Rest.COVER_JOB)
+  @PreAuthorize("hasRole('ROLE_ADMINISTRATOR')")
+  public ResponseEntity<Void> createRetryCoverDownloadJob() {
+    releaseService.createRetryCoverDownloadJob();
+    return ResponseEntity.ok().build();
+  }
 }

--- a/webapp/src/main/resources/application.yml
+++ b/webapp/src/main/resources/application.yml
@@ -71,5 +71,5 @@ metal-release-butler:
   host: http://localhost:8095
   unpaginated-releases-url: ${metal-release-butler.host}/rest/v1/releases/unpaginated
   import-url: ${metal-release-butler.host}/rest/v1/releases/import
-  cover-url: ${metal-release-butler.host}/rest/v1/releases/cover
+  cover-url: ${metal-release-butler.host}/rest/v1/releases/cover-reload
   access-token: ${BUTLER_ACCESS_TOKEN}

--- a/webapp/src/main/resources/application.yml
+++ b/webapp/src/main/resources/application.yml
@@ -71,4 +71,5 @@ metal-release-butler:
   host: http://localhost:8095
   unpaginated-releases-url: ${metal-release-butler.host}/rest/v1/releases/unpaginated
   import-url: ${metal-release-butler.host}/rest/v1/releases/import
+  cover-url: ${metal-release-butler.host}/rest/v1/releases/cover
   access-token: ${BUTLER_ACCESS_TOKEN}

--- a/webapp/src/main/resources/static/js/admin/import.js
+++ b/webapp/src/main/resources/static/js/admin/import.js
@@ -83,7 +83,7 @@ function createImportReleasesJob() {
 function createRetryCoverDownloadJob() {
   $.ajax({
     method: "POST",
-    url: "/rest/v1/releases/cover",
+    url: "/rest/v1/releases/cover-reload",
     success: function(){
       createToast("Job for retrying cover downloads successfully created!");
     },

--- a/webapp/src/main/resources/static/js/admin/import.js
+++ b/webapp/src/main/resources/static/js/admin/import.js
@@ -71,7 +71,20 @@ function createImportReleasesJob() {
       createToast("Import job successfully created!");
     },
     error: function(err){
-      createToast("Error during creating the import job: " + err);
+      createToast("Error creating the import job: " + err);
+    }
+  });
+}
+
+function createRetryCoverDownloadJob() {
+  $.ajax({
+    method: "POST",
+    url: "/rest/v1/releases/cover",
+    success: function(){
+      createToast("Job for retrying cover downloads successfully created!");
+    },
+    error: function(err){
+      createToast("Error creating the cover download job: " + err);
     }
   });
 }

--- a/webapp/src/main/resources/static/js/admin/import.js
+++ b/webapp/src/main/resources/static/js/admin/import.js
@@ -76,6 +76,10 @@ function createImportReleasesJob() {
   });
 }
 
+/**
+ * Creates a job for retrying cover downloads
+ * @returns {boolean}
+ */
 function createRetryCoverDownloadJob() {
   $.ajax({
     method: "POST",

--- a/webapp/src/main/resources/templates/admin/import.html
+++ b/webapp/src/main/resources/templates/admin/import.html
@@ -15,6 +15,7 @@
     <section layout:fragment="content">
         <h1 class="h2 text-dark">Import</h1>
         <button type="button" class="btn btn-dark btn-sm mt-2 mb-3" id="import-button" onclick="createImportReleasesJob()">Create Import Job</button>
+        <button type="button" class="btn btn-dark btn-sm mt-2 mb-3" id="retry-cover-download-button" onclick="createRetryCoverDownloadJob()">Create Retry Cover Download Job</button>
         <table id="import-job-table" class="table table-striped table-hover mt-3 clickable-table">
             <thead>
             <tr>

--- a/webapp/src/test/java/rocks/metaldetector/web/controller/rest/ReleasesRestControllerIT.java
+++ b/webapp/src/test/java/rocks/metaldetector/web/controller/rest/ReleasesRestControllerIT.java
@@ -15,6 +15,7 @@ import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static rocks.metaldetector.config.constants.Endpoints.Rest.COVER_JOB;
 import static rocks.metaldetector.config.constants.Endpoints.Rest.IMPORT_JOB;
 import static rocks.metaldetector.config.constants.Endpoints.Rest.QUERY_RELEASES;
 
@@ -57,6 +58,15 @@ public class ReleasesRestControllerIT extends BaseWebMvcTestWithSecurity {
               .contentType(APPLICATION_JSON))
               .andExpect(status().isOk());
     }
+
+    @Test
+    @DisplayName("Administrator is allowed to GET on endpoint " + COVER_JOB + "'")
+    @WithMockUser(roles = "ADMINISTRATOR")
+    void admin_is_allowed_to_query_cover_job_results() throws Exception {
+      mockMvc.perform(post(COVER_JOB)
+                          .contentType(APPLICATION_JSON))
+          .andExpect(status().isOk());
+    }
   }
 
   @Nested
@@ -88,6 +98,15 @@ public class ReleasesRestControllerIT extends BaseWebMvcTestWithSecurity {
       mockMvc.perform(get(IMPORT_JOB)
               .contentType(APPLICATION_JSON))
               .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("User is not allowed to GET on endpoint " + COVER_JOB + "'")
+    @WithMockUser(roles = "USER")
+    void user_is_not_allowed_to_query_cover_job_results() throws Exception {
+      mockMvc.perform(post(COVER_JOB)
+                          .contentType(APPLICATION_JSON))
+          .andExpect(status().isForbidden());
     }
   }
 }

--- a/webapp/src/test/java/rocks/metaldetector/web/controller/rest/ReleasesRestControllerIT.java
+++ b/webapp/src/test/java/rocks/metaldetector/web/controller/rest/ReleasesRestControllerIT.java
@@ -62,7 +62,7 @@ public class ReleasesRestControllerIT extends BaseWebMvcTestWithSecurity {
     @Test
     @DisplayName("Administrator is allowed to GET on endpoint " + COVER_JOB + "'")
     @WithMockUser(roles = "ADMINISTRATOR")
-    void admin_is_allowed_to_query_cover_job_results() throws Exception {
+    void admin_is_allowed_to_create_retry_cover_download_job() throws Exception {
       mockMvc.perform(post(COVER_JOB)
                           .contentType(APPLICATION_JSON))
           .andExpect(status().isOk());
@@ -103,7 +103,7 @@ public class ReleasesRestControllerIT extends BaseWebMvcTestWithSecurity {
     @Test
     @DisplayName("User is not allowed to GET on endpoint " + COVER_JOB + "'")
     @WithMockUser(roles = "USER")
-    void user_is_not_allowed_to_query_cover_job_results() throws Exception {
+    void user_not_is_allowed_to_create_retry_cover_download_job() throws Exception {
       mockMvc.perform(post(COVER_JOB)
                           .contentType(APPLICATION_JSON))
           .andExpect(status().isForbidden());


### PR DESCRIPTION
The new endpoint for retrying cover downloads is called. I made it look like there are really already jobs created on the butler side so we don't have to rename stuff here when the butler does acutally create the jobs.