### PR TITLE
Caching of Spotify Authentication Token

### DIFF
--- a/spotify/src/main/java/rocks/metaldetector/spotify/client/SpotifyAuthenticationClientImpl.java
+++ b/spotify/src/main/java/rocks/metaldetector/spotify/client/SpotifyAuthenticationClientImpl.java
@@ -3,6 +3,7 @@ package rocks.metaldetector.spotify.client;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.tomcat.util.codec.binary.Base64;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -36,6 +37,7 @@ public class SpotifyAuthenticationClientImpl implements SpotifyAuthenticationCli
   private final SpotifyConfig spotifyConfig;
 
   @Override
+  @Cacheable("spotifyAuthenticationToken")
   public String getAuthenticationToken() {
     HttpEntity<MultiValueMap<String, String>> httpEntity = createHttpEntity();
     ResponseEntity<SpotifyAuthenticationResponse> responseEntity = spotifyRestTemplate.postForEntity(

--- a/webapp/src/main/resources/config/cache/ehcache.xml
+++ b/webapp/src/main/resources/config/cache/ehcache.xml
@@ -29,4 +29,15 @@
         </resources>
     </cache>
 
+    <cache alias="spotifyAuthenticationToken">
+        <value-type>java.lang.String</value-type>
+
+        <expiry>
+            <ttl unit="minutes">59</ttl>
+        </expiry>
+
+        <resources>
+            <heap unit="MB">1</heap>
+        </resources>
+    </cache>
 </config>


### PR DESCRIPTION
This should be everything we have to do to cache the SpotifyAuthenticationToken. I used 59 minutes instead of one hour because the time starts "earlier" on their side. Otherwise it could happen that we think our token is still valid but then Spotify declines it because it is already invalid for them. Counting the request times in we should be safe with one minute backup time I guess.