### PR TITLE
change default ordering of import and release table in admin area

### DIFF
--- a/webapp/src/main/resources/static/js/admin/import.js
+++ b/webapp/src/main/resources/static/js/admin/import.js
@@ -31,6 +31,7 @@ function getImportJobs() {
       {"data": "finished"}
     ],
     "autoWidth": false, // fixes window resizing issue
+    "order": [[ 1, "desc" ]],
     "columnDefs": [
       {
         "targets": [1, 2],

--- a/webapp/src/main/resources/static/js/admin/releases.js
+++ b/webapp/src/main/resources/static/js/admin/releases.js
@@ -41,11 +41,23 @@ function getReleases() {
         {"data": "source"}
       ],
       "autoWidth": false, // fixes window resizing issue
+      "order": [[ 2, "asc" ], [0, "asc"]],
       "columnDefs": [
         {
           "targets": [2],
           "render": formatUtcDate
-        }
+        },
+        {
+          "targets": [3, 4],
+          "render": function (data) {
+            if (isEmpty(data)) {
+              return 'n/a';
+            }
+            else {
+              return data;
+            }
+          }
+        },
       ]
   });
 }

--- a/webapp/src/main/resources/static/js/util.js
+++ b/webapp/src/main/resources/static/js/util.js
@@ -12,7 +12,7 @@ function toggleLoader(id) {
  * @returns {boolean} true if the value is empty, false otherwise
  */
 function isEmpty(value) {
-  return typeof value === "undefined" || value.length === 0;
+  return typeof value === "undefined" || value === null || value.length === 0;
 }
 
 /**


### PR DESCRIPTION
The import table is now sorted in descending order by start date, so that the last import jobs are always shown on the first page.

The release table is sorted in ascending order by the release date. Then it is sorted in ascending order by the artist. 

In addition, empty fields (Metal Hammer does not provide a genre or album type) are marked with a 'n/a'.