### PR TITLE
remove isFollowed from ReleasesResponse

### DIFF
--- a/webapp/src/main/java/rocks/metaldetector/web/api/response/ReleasesResponse.java
+++ b/webapp/src/main/java/rocks/metaldetector/web/api/response/ReleasesResponse.java
@@ -25,6 +25,5 @@ public class ReleasesResponse {
   private String metalArchivesAlbumUrl;
   private String source;
   private String state;
-  private boolean isFollowed;
 
 }

--- a/webapp/src/main/java/rocks/metaldetector/web/controller/rest/ReleasesRestController.java
+++ b/webapp/src/main/java/rocks/metaldetector/web/controller/rest/ReleasesRestController.java
@@ -21,6 +21,7 @@ import rocks.metaldetector.web.transformer.ReleasesResponseTransformer;
 
 import javax.validation.Valid;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.springframework.http.HttpStatus.CREATED;
 
@@ -38,7 +39,7 @@ public class ReleasesRestController {
   public ResponseEntity<List<ReleasesResponse>> findAllReleases(@Valid @RequestBody ReleasesRequest request) {
     var timeRange = new TimeRange(request.getDateFrom(), request.getDateTo());
     List<ReleaseDto> releaseDtos = releaseService.findAllReleases(request.getArtists(), timeRange);
-    List<ReleasesResponse> response = releasesResponseTransformer.transformListOf(releaseDtos);
+    List<ReleasesResponse> response = releaseDtos.stream().map(releasesResponseTransformer::transform).collect(Collectors.toList());
     return ResponseEntity.ok(response);
   }
 
@@ -49,7 +50,7 @@ public class ReleasesRestController {
     var timeRange = new TimeRange(request.getDateFrom(), request.getDateTo());
     var pageRequest = new PageRequest(request.getPage(), request.getSize());
     List<ReleaseDto> releaseDtos = releaseService.findReleases(request.getArtists(), timeRange, pageRequest);
-    List<ReleasesResponse> response = releasesResponseTransformer.transformListOf(releaseDtos);
+    List<ReleasesResponse> response = releaseDtos.stream().map(releasesResponseTransformer::transform).collect(Collectors.toList());
     return ResponseEntity.ok(response);
   }
 

--- a/webapp/src/main/java/rocks/metaldetector/web/transformer/ReleasesResponseTransformer.java
+++ b/webapp/src/main/java/rocks/metaldetector/web/transformer/ReleasesResponseTransformer.java
@@ -3,27 +3,13 @@ package rocks.metaldetector.web.transformer;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
 import rocks.metaldetector.butler.facade.dto.ReleaseDto;
-import rocks.metaldetector.service.artist.ArtistDto;
-import rocks.metaldetector.service.artist.FollowArtistService;
 import rocks.metaldetector.web.api.response.ReleasesResponse;
-
-import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @AllArgsConstructor
 public class ReleasesResponseTransformer {
 
-  private final FollowArtistService followArtistService;
-
-  public List<ReleasesResponse> transformListOf(List<ReleaseDto> releases) {
-    var followedArtistsNames = followArtistService.getFollowedArtistsOfCurrentUser().stream().map(ArtistDto::getArtistName).collect(Collectors.toList());
-    return releases.stream()
-                   .map(release -> transform(release, followedArtistsNames))
-                   .collect(Collectors.toList());
-  }
-
-  private ReleasesResponse transform(ReleaseDto release, List<String> followedArtistsNames) {
+  public ReleasesResponse transform(ReleaseDto release) {
     return ReleasesResponse.builder()
             .artist(release.getArtist())
             .albumTitle(release.getAlbumTitle())
@@ -36,7 +22,6 @@ public class ReleasesResponseTransformer {
             .metalArchivesAlbumUrl(release.getMetalArchivesAlbumUrl())
             .source(release.getSource())
             .state(release.getState())
-            .isFollowed(followedArtistsNames.contains(release.getArtist()))
             .build();
   }
 }

--- a/webapp/src/test/java/rocks/metaldetector/web/controller/rest/ReleasesRestControllerTest.java
+++ b/webapp/src/test/java/rocks/metaldetector/web/controller/rest/ReleasesRestControllerTest.java
@@ -34,11 +34,11 @@ import rocks.metaldetector.web.transformer.ReleasesResponseTransformer;
 
 import java.time.LocalDate;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.stream.Stream;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
@@ -99,18 +99,20 @@ class ReleasesRestControllerTest implements WithAssertions {
     }
 
     @Test
-    @DisplayName("Should use transformer to transform releases to a list of ReleasesResponse")
+    @DisplayName("Should use transformer to transform each ReleaseDto")
     void should_use_releases_transformer() {
       // given
       var request = ReleaseRequestFactory.createDefault();
-      var releases = List.of(ReleaseDtoFactory.createDefault());
-      doReturn(releases).when(releasesService).findAllReleases(any(), any());
+      var release1 = ReleaseDtoFactory.withArtistName("Metallica");
+      var release2 = ReleaseDtoFactory.withArtistName("Slayer");
+      doReturn(List.of(release1, release2)).when(releasesService).findAllReleases(any(), any());
 
       // when
       restAssuredUtils.doPost(request);
 
       // then
-      verify(releasesResponseTransformer, times(1)).transformListOf(releases);
+      verify(releasesResponseTransformer, times(1)).transform(eq(release1));
+      verify(releasesResponseTransformer, times(1)).transform(eq(release2));
     }
 
     @Test
@@ -118,9 +120,9 @@ class ReleasesRestControllerTest implements WithAssertions {
     void should_return_releases() {
       // given
       var request = ReleaseRequestFactory.createDefault();
-      var transformedResponse = List.of(new ReleasesResponse());
-      doReturn(Collections.emptyList()).when(releasesService).findAllReleases(any(), any());
-      doReturn(transformedResponse).when(releasesResponseTransformer).transformListOf(any());
+      var transformedResponse = new ReleasesResponse();
+      doReturn(List.of(ReleaseDtoFactory.createDefault())).when(releasesService).findAllReleases(any(), any());
+      doReturn(transformedResponse).when(releasesResponseTransformer).transform(any());
 
       // when
       var validatableResponse = restAssuredUtils.doPost(request);
@@ -131,7 +133,7 @@ class ReleasesRestControllerTest implements WithAssertions {
           .statusCode(OK.value());
 
       var result = validatableResponse.extract().as(ReleasesResponse[].class);
-      assertThat(Arrays.asList(result)).isEqualTo(transformedResponse);
+      assertThat(Arrays.asList(result)).isEqualTo(List.of(transformedResponse));
     }
 
     @ParameterizedTest(name = "Should return 400 on invalid query request <{0}>")
@@ -189,18 +191,20 @@ class ReleasesRestControllerTest implements WithAssertions {
     }
 
     @Test
-    @DisplayName("Should use transformer to transform releases to a list of ReleasesResponse")
+    @DisplayName("Should use transformer to transform each ReleaseDto")
     void should_use_releases_transformer() {
       // given
       var request = PaginatedReleaseRequestFactory.createDefault();
-      var releases = List.of(ReleaseDtoFactory.createDefault());
-      doReturn(releases).when(releasesService).findReleases(any(), any(), any());
+      var release1 = ReleaseDtoFactory.withArtistName("Metallica");
+      var release2 = ReleaseDtoFactory.withArtistName("Slayer");
+      doReturn(List.of(release1, release2)).when(releasesService).findReleases(any(), any(), any());
 
       // when
       restAssuredUtils.doPost(request);
 
       // then
-      verify(releasesResponseTransformer, times(1)).transformListOf(releases);
+      verify(releasesResponseTransformer, times(1)).transform(eq(release1));
+      verify(releasesResponseTransformer, times(1)).transform(eq(release2));
     }
 
     @Test
@@ -208,9 +212,9 @@ class ReleasesRestControllerTest implements WithAssertions {
     void should_return_releases() {
       // given
       var request = PaginatedReleaseRequestFactory.createDefault();
-      var transformedResponse = List.of(new ReleasesResponse());
-      doReturn(Collections.emptyList()).when(releasesService).findReleases(any(), any(), any());
-      doReturn(transformedResponse).when(releasesResponseTransformer).transformListOf(any());
+      var transformedResponse = new ReleasesResponse();
+      doReturn(List.of(ReleaseDtoFactory.createDefault())).when(releasesService).findReleases(any(), any(), any());
+      doReturn(transformedResponse).when(releasesResponseTransformer).transform(any());
 
       // when
       var validatableResponse = restAssuredUtils.doPost(request);
@@ -221,7 +225,7 @@ class ReleasesRestControllerTest implements WithAssertions {
               .statusCode(OK.value());
 
       var result = validatableResponse.extract().as(ReleasesResponse[].class);
-      assertThat(Arrays.asList(result)).isEqualTo(transformedResponse);
+      assertThat(Arrays.asList(result)).isEqualTo(List.of(transformedResponse));
     }
 
     @ParameterizedTest(name = "Should return 400 on invalid query request <{0}>")

--- a/webapp/src/test/java/rocks/metaldetector/web/transformer/ReleasesResponseTransformerTest.java
+++ b/webapp/src/test/java/rocks/metaldetector/web/transformer/ReleasesResponseTransformerTest.java
@@ -1,102 +1,34 @@
 package rocks.metaldetector.web.transformer;
 
 import org.assertj.core.api.WithAssertions;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import rocks.metaldetector.service.artist.FollowArtistService;
-import rocks.metaldetector.testutil.DtoFactory;
 
-import java.util.Collections;
-import java.util.List;
-
-import static org.mockito.Mockito.reset;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 import static rocks.metaldetector.testutil.DtoFactory.ReleaseDtoFactory;
 
-@ExtendWith(MockitoExtension.class)
 class ReleasesResponseTransformerTest implements WithAssertions {
 
-  @Mock
-  private FollowArtistService followArtistService;
-
-  @InjectMocks
-  private ReleasesResponseTransformer underTest;
-
-  @AfterEach
-  void tearDown() {
-    reset(followArtistService);
-  }
+  private final ReleasesResponseTransformer underTest = new ReleasesResponseTransformer();
 
   @Test
-  @DisplayName("Should transform list of ReleaseDto to a list of ReleasesResponse")
+  @DisplayName("Should transform ReleasesResponseDto")
   void should_transform() {
     // given
-    String artistName1 = "Metallica";
-    String artistName2 = "Slayer";
-    var releases = List.of(
-            ReleaseDtoFactory.withArtistName(artistName1),
-            ReleaseDtoFactory.withArtistName(artistName2)
-    );
-    when(followArtistService.getFollowedArtistsOfCurrentUser()).thenReturn(Collections.emptyList());
+    var releaseDto = ReleaseDtoFactory.withArtistName("Metallica");
 
     // when
-    var results = underTest.transformListOf(releases);
+    var response = underTest.transform(releaseDto);
 
     // then
-    assertThat(results.size()).isEqualTo(releases.size());
-
-    for (int index = 0; index < releases.size(); index++) {
-      var release = releases.get(index);
-      var resultItem = results.get(index);
-      assertThat(resultItem.getArtist()).isEqualTo(release.getArtist());
-      assertThat(resultItem.getAlbumTitle()).isEqualTo(release.getAlbumTitle());
-      assertThat(resultItem.getReleaseDate()).isEqualTo(release.getReleaseDate());
-      assertThat(resultItem.getAdditionalArtists()).isEqualTo(release.getAdditionalArtists());
-      assertThat(resultItem.getGenre()).isEqualTo(release.getGenre());
-      assertThat(resultItem.getType()).isEqualTo(release.getType());
-      assertThat(resultItem.getMetalArchivesArtistUrl()).isEqualTo(release.getMetalArchivesArtistUrl());
-      assertThat(resultItem.getMetalArchivesAlbumUrl()).isEqualTo(release.getMetalArchivesAlbumUrl());
-      assertThat(resultItem.getSource()).isEqualTo(release.getSource());
-      assertThat(resultItem.getState()).isEqualTo(release.getState());
-      assertThat(resultItem.isFollowed()).isFalse();
-    }
-  }
-
-  @Test
-  @DisplayName("Should mark all followed artists by the current user")
-  void should_mark_as_followed() {
-    // given
-    var releases = List.of(
-            ReleaseDtoFactory.withArtistName("1"),
-            ReleaseDtoFactory.withArtistName("2")
-    );
-    when(followArtistService.getFollowedArtistsOfCurrentUser()).thenReturn(List.of(DtoFactory.ArtistDtoFactory.withName("1")));
-
-    // when
-    var results = underTest.transformListOf(releases);
-
-    // then
-    assertThat(results.get(0).isFollowed()).isTrue();
-    assertThat(results.get(1).isFollowed()).isFalse();
-  }
-
-  @Test
-  @DisplayName("Should call followArtistService to get followed artists")
-  void should_call_service() {
-    // given
-    when(followArtistService.getFollowedArtistsOfCurrentUser()).thenReturn(Collections.emptyList());
-
-    // when
-    underTest.transformListOf(Collections.emptyList());
-
-    // then
-    verify(followArtistService, times(1)).getFollowedArtistsOfCurrentUser();
+    assertThat(response.getArtist()).isEqualTo(releaseDto.getArtist());
+    assertThat(response.getAlbumTitle()).isEqualTo(releaseDto.getAlbumTitle());
+    assertThat(response.getReleaseDate()).isEqualTo(releaseDto.getReleaseDate());
+    assertThat(response.getAdditionalArtists()).isEqualTo(releaseDto.getAdditionalArtists());
+    assertThat(response.getGenre()).isEqualTo(releaseDto.getGenre());
+    assertThat(response.getType()).isEqualTo(releaseDto.getType());
+    assertThat(response.getMetalArchivesArtistUrl()).isEqualTo(releaseDto.getMetalArchivesArtistUrl());
+    assertThat(response.getMetalArchivesAlbumUrl()).isEqualTo(releaseDto.getMetalArchivesAlbumUrl());
+    assertThat(response.getSource()).isEqualTo(releaseDto.getSource());
+    assertThat(response.getState()).isEqualTo(releaseDto.getState());
   }
 }


### PR DESCRIPTION
I've removed the `isFollowed` attribute from `ReleasesResponse`. We only needed it when we displayed the releases in tabular form in the frontend and wanted to filter by releases of the following artists. 