### PR TITLE
Dependency updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.3.1.RELEASE</version>
+        <version>2.3.2.RELEASE</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
@@ -51,15 +51,13 @@
 
     <properties>
         <jsonwebtoken.version>0.9.1</jsonwebtoken.version>
-        <modelmapper.version>2.3.6</modelmapper.version>
-        <junit-jupiter.version>5.6.0</junit-jupiter.version>
+        <modelmapper.version>2.3.8</modelmapper.version>
+        <junit-jupiter.version>5.6.2</junit-jupiter.version>
         <mockito.version>3.1.0</mockito.version>
         <coveralls-plugin.version>4.3.0</coveralls-plugin.version>
         <jaxb-api.version>2.3.1</jaxb-api.version>
         <jacoco.version>0.8.5</jacoco.version>
-        <apache-commons.version>1.8</apache-commons.version>
-<!--    https://trello.com/c/bJI3GDuL groovy-3 is needed because of trouble with rest-assured (pulls older groovy) and java 14-->
-        <custom-groovy.version>3.0.3</custom-groovy.version>
+        <apache-commons.version>1.9</apache-commons.version>
     </properties>
 
     <dependencies>
@@ -70,11 +68,6 @@
         <dependency>
             <groupId>org.ehcache</groupId>
             <artifactId>ehcache</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.codehaus.groovy</groupId>
-            <artifactId>groovy</artifactId>
-            <version>${custom-groovy.version}</version>
         </dependency>
 
         <!-- Security -->
@@ -157,18 +150,6 @@
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.codehaus.groovy</groupId>
-            <artifactId>groovy-json</artifactId>
-            <version>${custom-groovy.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.codehaus.groovy</groupId>
-            <artifactId>groovy-xml</artifactId>
-            <version>${custom-groovy.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -18,12 +18,12 @@
         <java.version>14</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <hibernate-validator.version>6.1.2.Final</hibernate-validator.version>
+        <hibernate-validator.version>6.1.5.Final</hibernate-validator.version>
         <validation-api.version>2.0.1.Final</validation-api.version>
         <material-icons.version>0.3.1</material-icons.version>
-        <rest-assured.version>4.3.1</rest-assured.version>
-        <bootstrap.version>4.5.0</bootstrap.version>
-        <datatables.version>1.10.20</datatables.version>
+        <rest-assured.version>4.2.0</rest-assured.version>
+        <bootstrap.version>4.5.2</bootstrap.version>
+        <datatables.version>1.10.21</datatables.version>
         <thymeleaf-dialect.version>2.4.1</thymeleaf-dialect.version>
     </properties>
 


### PR DESCRIPTION
Updates for spring boot and several other dependencies. I downgraded rest-assured from 4.3.0 to 4.2.0 to get rid of the groovy dependency. Apparently this is an issue in 4.3.0 (and 4.3.1) that also exists in other Java Version than 14. So let's just wait here.
I didn't manage to get Mockito updated so it's still 3.1.0. I'll create a dependency card for these two points.