### PR TITLE
Recently followed artists on homepage and mock deactivation

### DIFF
--- a/persistence/src/main/java/rocks/metaldetector/persistence/domain/artist/ArtistEntity.java
+++ b/persistence/src/main/java/rocks/metaldetector/persistence/domain/artist/ArtistEntity.java
@@ -2,6 +2,7 @@ package rocks.metaldetector.persistence.domain.artist;
 
 import lombok.AccessLevel;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
@@ -17,6 +18,7 @@ import javax.persistence.Enumerated;
 @Entity(name = "artists")
 @NoArgsConstructor(access = AccessLevel.PROTECTED) // for hibernate and model mapper
 @ToString
+@EqualsAndHashCode(callSuper = true)
 public class ArtistEntity extends BaseEntity {
 
   @Column(name = "external_id", nullable = false, updatable = false)

--- a/persistence/src/main/java/rocks/metaldetector/persistence/domain/artist/ArtistRepository.java
+++ b/persistence/src/main/java/rocks/metaldetector/persistence/domain/artist/ArtistRepository.java
@@ -18,9 +18,9 @@ public interface ArtistRepository extends JpaRepository<ArtistEntity, Long> {
 
   boolean existsByExternalIdAndSource(String externalId, ArtistSource source);
 
-  @Query(value = "select a.artist_name as artistName, a.thumb as thumb " +
+  @Query(value = "select a.artist_name as artistName, a.thumb as thumb, a.external_id as externalId " +
                  "from artists as a left join follow_actions as fa on a.id = fa.artist_id " +
-                 "group by a.artist_name, a.thumb " +
+                 "group by a.artist_name, a.thumb, a.external_id " +
                  "order by count(a.id) desc " +
                  "limit :limit",
          nativeQuery = true)

--- a/persistence/src/main/java/rocks/metaldetector/persistence/domain/artist/FollowActionEntity.java
+++ b/persistence/src/main/java/rocks/metaldetector/persistence/domain/artist/FollowActionEntity.java
@@ -3,6 +3,7 @@ package rocks.metaldetector.persistence.domain.artist;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
@@ -20,6 +21,7 @@ import javax.persistence.OneToOne;
 @AllArgsConstructor(access = AccessLevel.PRIVATE) // for lombok builder
 @Builder
 @ToString
+@EqualsAndHashCode(callSuper = true)
 public class FollowActionEntity extends BaseEntity {
 
   @OneToOne(targetEntity = UserEntity.class)

--- a/persistence/src/main/java/rocks/metaldetector/persistence/domain/artist/TopArtist.java
+++ b/persistence/src/main/java/rocks/metaldetector/persistence/domain/artist/TopArtist.java
@@ -2,6 +2,7 @@ package rocks.metaldetector.persistence.domain.artist;
 
 public interface TopArtist {
 
+  String getExternalId();
   String getArtistName();
   String getThumb();
 }

--- a/persistence/src/test/java/rocks/metaldetector/persistence/domain/artist/ArtistRepositoryIT.java
+++ b/persistence/src/test/java/rocks/metaldetector/persistence/domain/artist/ArtistRepositoryIT.java
@@ -163,9 +163,11 @@ class ArtistRepositoryIT extends BaseDataJpaTest implements WithAssertions, With
     assertThat(result).hasSize(limit);
     assertThat(result.get(0).getArtistName()).isEqualTo(artist3.getArtistName());
     assertThat(result.get(0).getThumb()).isEqualTo(artist3.getThumb());
+    assertThat(result.get(0).getExternalId()).isEqualTo(artist3.getExternalId());
 
     assertThat(result.get(1).getArtistName()).isEqualTo(artist2.getArtistName());
     assertThat(result.get(1).getThumb()).isEqualTo(artist2.getThumb());
+    assertThat(result.get(1).getExternalId()).isEqualTo(artist2.getExternalId());
   }
 
   @Test

--- a/webapp/src/main/java/rocks/metaldetector/service/artist/ArtistDto.java
+++ b/webapp/src/main/java/rocks/metaldetector/service/artist/ArtistDto.java
@@ -18,5 +18,6 @@ public class ArtistDto {
   private String thumb;
   private String source;
   private LocalDate followedSince;
+  private int follower;
 
 }

--- a/webapp/src/main/java/rocks/metaldetector/service/artist/ArtistTransformer.java
+++ b/webapp/src/main/java/rocks/metaldetector/service/artist/ArtistTransformer.java
@@ -19,6 +19,7 @@ public class ArtistTransformer {
 
   public ArtistDto transform(TopArtist topArtist) {
     return ArtistDto.builder()
+        .externalId(topArtist.getExternalId())
         .artistName(topArtist.getArtistName())
         .thumb(topArtist.getThumb())
         .build();

--- a/webapp/src/main/java/rocks/metaldetector/service/summary/ArtistCollector.java
+++ b/webapp/src/main/java/rocks/metaldetector/service/summary/ArtistCollector.java
@@ -3,9 +3,16 @@ package rocks.metaldetector.service.summary;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Component;
 import rocks.metaldetector.persistence.domain.artist.ArtistRepository;
+import rocks.metaldetector.persistence.domain.artist.FollowActionEntity;
+import rocks.metaldetector.persistence.domain.artist.FollowActionRepository;
+import rocks.metaldetector.persistence.domain.user.UserEntity;
+import rocks.metaldetector.persistence.domain.user.UserRepository;
+import rocks.metaldetector.security.CurrentPublicUserIdSupplier;
 import rocks.metaldetector.service.artist.ArtistDto;
 import rocks.metaldetector.service.artist.ArtistTransformer;
+import rocks.metaldetector.support.exceptions.ResourceNotFoundException;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -17,9 +24,25 @@ public class ArtistCollector {
 
   private final ArtistRepository artistRepository;
   private final ArtistTransformer artistTransformer;
+  private final FollowActionRepository followActionRepository;
+  private final UserRepository userRepository;
+  private final CurrentPublicUserIdSupplier currentPublicUserIdSupplier;
 
   public List<ArtistDto> collectTopFollowedArtists() {
     return artistRepository.findTopArtists(RESULT_LIMIT).stream()
+        .map(artistTransformer::transform)
+        .peek(artist -> artist.setFollower(artistRepository.countArtistFollower(artist.getExternalId())))
+        .collect(Collectors.toList());
+  }
+
+  public List<ArtistDto> collectRecentlyFollowedArtists() {
+    String publicUserId = currentPublicUserIdSupplier.get();
+    UserEntity currentUser = userRepository.findByPublicId(publicUserId)
+        .orElseThrow(() -> new ResourceNotFoundException("User with public id '" + publicUserId + "' not found!"));
+
+    return followActionRepository.findAllByUser(currentUser).stream()
+        .sorted(Comparator.comparing(FollowActionEntity::getCreatedDateTime).reversed())
+        .limit(RESULT_LIMIT)
         .map(artistTransformer::transform)
         .collect(Collectors.toList());
   }

--- a/webapp/src/main/java/rocks/metaldetector/service/summary/SummaryServiceImpl.java
+++ b/webapp/src/main/java/rocks/metaldetector/service/summary/SummaryServiceImpl.java
@@ -1,6 +1,8 @@
 package rocks.metaldetector.service.summary;
 
 import lombok.AllArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
 import rocks.metaldetector.butler.facade.dto.ReleaseDto;
 import rocks.metaldetector.service.artist.ArtistDto;
 import rocks.metaldetector.service.artist.FollowArtistService;
@@ -8,6 +10,8 @@ import rocks.metaldetector.web.api.response.SummaryResponse;
 
 import java.util.List;
 
+@Service
+@Profile({"default", "preview", "prod"})
 @AllArgsConstructor
 public class SummaryServiceImpl implements SummaryService {
 
@@ -22,6 +26,7 @@ public class SummaryServiceImpl implements SummaryService {
   public SummaryResponse createSummaryResponse() {
     List<ArtistDto> currentUsersFollowedArtists = followArtistService.getFollowedArtistsOfCurrentUser();
     List<ArtistDto> mostFollowedArtists = artistCollector.collectTopFollowedArtists();
+    List<ArtistDto> recentlyFollowedArtists = artistCollector.collectRecentlyFollowedArtists();
 
     List<ReleaseDto> upcomingReleases = releaseCollector.collectUpcomingReleases(currentUsersFollowedArtists);
     List<ReleaseDto> recentReleases = releaseCollector.collectRecentReleases(currentUsersFollowedArtists);
@@ -32,6 +37,7 @@ public class SummaryServiceImpl implements SummaryService {
         .recentReleases(recentReleases)
         .favoriteCommunityArtists(mostFollowedArtists)
         .mostExpectedReleases(mostExpectedReleases)
+        .recentlyFollowedArtists(recentlyFollowedArtists)
         .build();
   }
 }

--- a/webapp/src/main/java/rocks/metaldetector/service/summary/SummaryServiceMock.java
+++ b/webapp/src/main/java/rocks/metaldetector/service/summary/SummaryServiceMock.java
@@ -1,5 +1,6 @@
 package rocks.metaldetector.service.summary;
 
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 import rocks.metaldetector.butler.facade.dto.ReleaseDto;
 import rocks.metaldetector.service.artist.ArtistDto;
@@ -9,6 +10,7 @@ import java.time.LocalDate;
 import java.util.List;
 
 @Service
+@Profile("mockmode")
 public class SummaryServiceMock implements SummaryService {
 
   @Override
@@ -43,10 +45,10 @@ public class SummaryServiceMock implements SummaryService {
   }
 
   private List<ArtistDto> createRecentlyFollowedArtists(LocalDate now) {
-    ArtistDto harakiriForTheSky = ArtistDto.builder().artistName("Harakiri For the Sky").thumb("/images/dummy/harakiri-for-the-sky.jpg").followedSince(now.minusDays(3)).build();
-    ArtistDto marduk = ArtistDto.builder().artistName("Marduk").thumb("/images/dummy/marduk.jpg").followedSince(now.minusDays(7)).build();
-    ArtistDto abbath = ArtistDto.builder().artistName("Abbath").thumb("/images/dummy/abbath.jpg").followedSince(now.minusDays(15)).build();
-    ArtistDto alcest = ArtistDto.builder().artistName("Alcest").thumb("/images/dummy/alcest.jpg").followedSince(now.minusDays(26)).build();
+    ArtistDto harakiriForTheSky = ArtistDto.builder().artistName("Harakiri For the Sky").thumb("/images/dummy/harakiri-for-the-sky.jpg").followedSince(now.minusDays(3)).follower(666).build();
+    ArtistDto marduk = ArtistDto.builder().artistName("Marduk").thumb("/images/dummy/marduk.jpg").followedSince(now.minusDays(7)).follower(666).build();
+    ArtistDto abbath = ArtistDto.builder().artistName("Abbath").thumb("/images/dummy/abbath.jpg").followedSince(now.minusDays(15)).follower(666).build();
+    ArtistDto alcest = ArtistDto.builder().artistName("Alcest").thumb("/images/dummy/alcest.jpg").followedSince(now.minusDays(26)).follower(666).build();
     return List.of(alcest, abbath, marduk, harakiriForTheSky);
   }
 }

--- a/webapp/src/main/resources/static/ts/src/model/artist.model.ts
+++ b/webapp/src/main/resources/static/ts/src/model/artist.model.ts
@@ -5,5 +5,6 @@ export interface Artist {
     readonly thumb: string;
     readonly followedSince: string;
     readonly source: string;
+    readonly follower: number;
 
 }

--- a/webapp/src/main/resources/static/ts/src/service/homepage-render-service.ts
+++ b/webapp/src/main/resources/static/ts/src/service/homepage-render-service.ts
@@ -72,7 +72,7 @@ export class HomepageRenderService extends AbstractRenderService<HomepageRespons
 
             response.recentlyFollowedArtists.forEach(artist => {
                 const artistDivElement = this.renderArtistCard(artist);
-                const followedSinceElement = artistDivElement.querySelector("#artist-followed-since") as HTMLDivElement;
+                const followedSinceElement = artistDivElement.querySelector("#artist-sub-title") as HTMLDivElement;
                 followedSinceElement.innerHTML = this.dateFormatService.formatRelative(artist.followedSince);
                 this.attachCard(artistDivElement, recentlyFollowedRowElement);
             });
@@ -86,6 +86,8 @@ export class HomepageRenderService extends AbstractRenderService<HomepageRespons
 
             response.favoriteCommunityArtists.forEach(artist => {
                 const artistDivElement = this.renderArtistCard(artist);
+                const followerElement = artistDivElement.querySelector("#artist-sub-title") as HTMLDivElement;
+                followerElement.innerHTML = artist.follower + " follower";
                 this.attachCard(artistDivElement, recentlyFollowedRowElement);
             });
         }

--- a/webapp/src/main/resources/templates/frontend/home.html
+++ b/webapp/src/main/resources/templates/frontend/home.html
@@ -17,7 +17,7 @@
                     <div class="card-body">
                         <p class="h5 card-title" id="artist-name"></p>
                     </div>
-                    <div class="card-footer text-muted" id="artist-followed-since">
+                    <div class="card-footer text-muted" id="artist-sub-title">
                     </div>
                 </div>
             </div>

--- a/webapp/src/test/java/rocks/metaldetector/service/artist/ArtistServiceImplTest.java
+++ b/webapp/src/test/java/rocks/metaldetector/service/artist/ArtistServiceImplTest.java
@@ -4,13 +4,11 @@ import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.domain.PageRequest;
 import rocks.metaldetector.discogs.facade.DiscogsService;
 import rocks.metaldetector.persistence.domain.artist.ArtistEntity;
 import rocks.metaldetector.persistence.domain.artist.ArtistRepository;
@@ -19,30 +17,19 @@ import rocks.metaldetector.persistence.domain.user.UserEntity;
 import rocks.metaldetector.persistence.domain.user.UserRepository;
 import rocks.metaldetector.security.CurrentPublicUserIdSupplier;
 import rocks.metaldetector.spotify.facade.SpotifyService;
-import rocks.metaldetector.support.exceptions.ResourceNotFoundException;
 import rocks.metaldetector.testutil.DtoFactory.ArtistDtoFactory;
-import rocks.metaldetector.testutil.DtoFactory.DiscogsArtistSearchResultDtoFactory;
-import rocks.metaldetector.web.api.response.ArtistSearchResponse;
-import rocks.metaldetector.web.api.response.ArtistSearchResponseEntryDto;
 import rocks.metaldetector.web.transformer.ArtistSearchResponseTransformer;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.UUID;
 
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static rocks.metaldetector.persistence.domain.artist.ArtistSource.DISCOGS;
-import static rocks.metaldetector.testutil.DtoFactory.ArtistSearchResponseEntryDtoFactory;
-import static rocks.metaldetector.testutil.DtoFactory.ArtistSearchResponseFactory;
-import static rocks.metaldetector.testutil.DtoFactory.SpotifyArtistSearchResultDtoFactory;
 
 @ExtendWith(MockitoExtension.class)
 class ArtistServiceImplTest implements WithAssertions {
@@ -89,7 +76,7 @@ class ArtistServiceImplTest implements WithAssertions {
   @BeforeEach
   void setUp() {
     artistEntity = new ArtistEntity(EXTERNAL_ID, ARTIST_NAME, null, DISCOGS);
-    artistDto = new ArtistDto(EXTERNAL_ID, ARTIST_NAME, null, "Discogs", null);
+    artistDto = new ArtistDto(EXTERNAL_ID, ARTIST_NAME, null, "Discogs", null, 666);
   }
 
   @Test

--- a/webapp/src/test/java/rocks/metaldetector/service/artist/ArtistTransformerTest.java
+++ b/webapp/src/test/java/rocks/metaldetector/service/artist/ArtistTransformerTest.java
@@ -40,6 +40,7 @@ class ArtistTransformerTest implements WithAssertions {
     TopArtist topArtist = mock(TopArtist.class);
     doReturn("artist").when(topArtist).getArtistName();
     doReturn("thumb").when(topArtist).getThumb();
+    doReturn("externalId").when(topArtist).getExternalId();
 
     // when
     ArtistDto result = underTest.transform(topArtist);
@@ -47,6 +48,7 @@ class ArtistTransformerTest implements WithAssertions {
     // then
     assertThat(result.getArtistName()).isEqualTo(topArtist.getArtistName());
     assertThat(result.getThumb()).isEqualTo(topArtist.getThumb());
+    assertThat(result.getExternalId()).isEqualTo(topArtist.getExternalId());
   }
 
   @Test

--- a/webapp/src/test/java/rocks/metaldetector/service/summary/ArtistCollectorTest.java
+++ b/webapp/src/test/java/rocks/metaldetector/service/summary/ArtistCollectorTest.java
@@ -8,15 +8,30 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import rocks.metaldetector.persistence.domain.artist.ArtistEntity;
 import rocks.metaldetector.persistence.domain.artist.ArtistRepository;
+import rocks.metaldetector.persistence.domain.artist.FollowActionEntity;
+import rocks.metaldetector.persistence.domain.artist.FollowActionRepository;
 import rocks.metaldetector.persistence.domain.artist.TopArtist;
+import rocks.metaldetector.persistence.domain.user.UserEntity;
+import rocks.metaldetector.persistence.domain.user.UserRepository;
+import rocks.metaldetector.security.CurrentPublicUserIdSupplier;
+import rocks.metaldetector.service.artist.ArtistEntityFactory;
 import rocks.metaldetector.service.artist.ArtistTransformer;
+import rocks.metaldetector.service.user.UserEntityFactory;
+import rocks.metaldetector.support.exceptions.ResourceNotFoundException;
 import rocks.metaldetector.testutil.DtoFactory.ArtistDtoFactory;
 
+import java.time.Instant;
+import java.util.Date;
 import java.util.List;
+import java.util.Optional;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
@@ -32,16 +47,27 @@ class ArtistCollectorTest implements WithAssertions {
   @Mock
   private ArtistTransformer artistTransformer;
 
+  @Mock
+  private CurrentPublicUserIdSupplier currentPublicUserIdSupplier;
+
+  @Mock
+  private UserRepository userRepository;
+
+  @Mock
+  private FollowActionRepository followActionRepository;
+
   @InjectMocks
   private ArtistCollector underTest;
 
+  private final UserEntity userEntity = UserEntityFactory.createUser("user", "user@mail.com");
+
   @AfterEach
   void tearDown() {
-    reset(artistRepository, artistTransformer);
+    reset(artistRepository, artistTransformer, currentPublicUserIdSupplier, userRepository, followActionRepository);
   }
 
   @Test
-  @DisplayName("artistRepository is called to get top artists")
+  @DisplayName("collectTopFollowedArtists: artistRepository is called to get top artists")
   void test_artist_repository_is_called_for_top_artists() {
     // when
     underTest.collectTopFollowedArtists();
@@ -51,7 +77,7 @@ class ArtistCollectorTest implements WithAssertions {
   }
 
   @Test
-  @DisplayName("artistTransformer is called for each artist")
+  @DisplayName("collectTopFollowedArtists: artistTransformer is called for each artist")
   void test_artist_transformer_is_called_for_artists() {
     // given
     var topArtists = List.of(mock(TopArtist.class), mock(TopArtist.class));
@@ -66,7 +92,7 @@ class ArtistCollectorTest implements WithAssertions {
   }
 
   @Test
-  @DisplayName("artist dtos are returned")
+  @DisplayName("collectTopFollowedArtists: artist dtos are returned")
   void test_artist_dtos_are_returned() {
     // given
     var artistEntities = List.of(mock(TopArtist.class), mock(TopArtist.class));
@@ -80,5 +106,85 @@ class ArtistCollectorTest implements WithAssertions {
 
     // then
     assertThat(result).isEqualTo(expectedArtistDtos);
+  }
+
+  @Test
+  @DisplayName("collectRecentlyFollowedArtists: currentPublicUserIdSupplier is called")
+  void test_current_user_id_supplier_called() {
+    // given
+    doReturn(Optional.of(userEntity)).when(userRepository).findByPublicId(any());
+
+    // when
+    underTest.collectRecentlyFollowedArtists();
+
+    // then
+    verify(currentPublicUserIdSupplier, times(1)).get();
+  }
+
+  @Test
+  @DisplayName("collectTopFollowedArtists: userRepository is called")
+  void test_user_repository_called() {
+    // given
+    var userId = "userId";
+    doReturn(userId).when(currentPublicUserIdSupplier).get();
+    doReturn(Optional.of(userEntity)).when(userRepository).findByPublicId(any());
+
+    // when
+    underTest.collectRecentlyFollowedArtists();
+
+    // then
+    verify(userRepository, times(1)).findByPublicId(userId);
+  }
+
+  @Test
+  @DisplayName("collectTopFollowedArtists: userRepository throws exception when publicUserId not found")
+  void test_user_repository_throws_exception() {
+    // given
+    var publicUserId = "publicUserId";
+    doThrow(new ResourceNotFoundException(publicUserId)).when(userRepository).findByPublicId(publicUserId);
+
+    // when
+    Throwable throwable = catchThrowable(() -> underTest.collectRecentlyFollowedArtists());
+
+    // then
+    assertThat(throwable).isInstanceOf(ResourceNotFoundException.class);
+    assertThat(throwable).hasMessageContaining(publicUserId);
+  }
+
+  @Test
+  @DisplayName("collectTopFollowedArtists: followActionRepository is called with user")
+  void test_follow_action_repository_called() {
+    // given
+    doReturn(Optional.of(userEntity)).when(userRepository).findByPublicId(any());
+
+    // when
+    underTest.collectRecentlyFollowedArtists();
+
+    // then
+    verify(followActionRepository, times(1)).findAllByUser(userEntity);
+  }
+
+  @Test
+  @DisplayName("collectTopFollowedArtists: artistTransformer is called for every followActionEntity")
+  void test_artist_transformer_called() {
+    // given
+    ArtistEntity artist1 = ArtistEntityFactory.withExternalId("1");
+    ArtistEntity artist2 = ArtistEntityFactory.withExternalId("2");
+    FollowActionEntity userFollowsArtist1 = FollowActionEntity.builder().user(userEntity).artist(artist1).build();
+    FollowActionEntity userFollowsArtist2 = FollowActionEntity.builder().user(userEntity).artist(artist2).build();
+    userFollowsArtist1.setCreatedDateTime(Date.from(Instant.now()));
+    userFollowsArtist2.setCreatedDateTime(Date.from(Instant.now()));
+    var followActionEntities = List.of(userFollowsArtist1, userFollowsArtist2);
+    doReturn(Optional.of(userEntity)).when(userRepository).findByPublicId(any());
+    doReturn(followActionEntities).when(followActionRepository).findAllByUser(any());
+    doReturn(ArtistDtoFactory.createDefault()).when(artistTransformer).transform(userFollowsArtist1);
+    doReturn(ArtistDtoFactory.createDefault()).when(artistTransformer).transform(userFollowsArtist2);
+
+    // when
+    underTest.collectRecentlyFollowedArtists();
+
+    // then
+    verify(artistTransformer, times(1)).transform(eq(userFollowsArtist1));
+    verify(artistTransformer, times(1)).transform(eq(userFollowsArtist2));
   }
 }

--- a/webapp/src/test/java/rocks/metaldetector/service/summary/ArtistCollectorTest.java
+++ b/webapp/src/test/java/rocks/metaldetector/service/summary/ArtistCollectorTest.java
@@ -26,6 +26,8 @@ import java.sql.Date;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static java.time.temporal.ChronoUnit.DAYS;
 import static org.mockito.ArgumentMatchers.any;
@@ -211,19 +213,15 @@ class ArtistCollectorTest implements WithAssertions {
     inOrder.verify(artistTransformer, times(1)).transform(userFollowsArtist1);
   }
 
-
   @Test
   @DisplayName("collectRecentlyFollowedArtists: result size is limited")
   void test_result_limited() {
     // given
     var artist = ArtistEntityFactory.withExternalId("1");
-    var userFollowsArtist1 = FollowActionEntity.builder().user(userEntity).artist(artist).build();
-    var userFollowsArtist2 = FollowActionEntity.builder().user(userEntity).artist(artist).build();
-    var userFollowsArtist3 = FollowActionEntity.builder().user(userEntity).artist(artist).build();
-    var userFollowsArtist4 = FollowActionEntity.builder().user(userEntity).artist(artist).build();
-    var userFollowsArtist5 = FollowActionEntity.builder().user(userEntity).artist(artist).build();
-    var followActionEntities = List.of(userFollowsArtist1, userFollowsArtist2, userFollowsArtist3, userFollowsArtist4, userFollowsArtist5);
-    followActionEntities.forEach(action -> action.setCreatedDateTime(Date.from(Instant.now())));
+    var followActionEntities = IntStream.rangeClosed(1, RESULT_LIMIT + 1)
+        .mapToObj(value -> FollowActionEntity.builder().user(userEntity).artist(artist).build())
+        .peek(action -> action.setCreatedDateTime(Date.from(Instant.now())))
+        .collect(Collectors.toList());
     doReturn(Optional.of(userEntity)).when(userRepository).findByPublicId(any());
     doReturn(followActionEntities).when(followActionRepository).findAllByUser(any());
 

--- a/webapp/src/test/java/rocks/metaldetector/service/summary/SummaryServiceImplTest.java
+++ b/webapp/src/test/java/rocks/metaldetector/service/summary/SummaryServiceImplTest.java
@@ -172,8 +172,8 @@ class SummaryServiceImplTest implements WithAssertions {
   }
 
   @Test
-  @DisplayName("")
-  void test_most_recently_followed_artists_returned() {
+  @DisplayName("recently followed artists are returned")
+  void test_recently_followed_artists_returned() {
     // given
     var artists = List.of(ArtistDtoFactory.createDefault());
     doReturn(artists).when(artistCollector).collectRecentlyFollowedArtists();

--- a/webapp/src/test/java/rocks/metaldetector/service/summary/SummaryServiceImplTest.java
+++ b/webapp/src/test/java/rocks/metaldetector/service/summary/SummaryServiceImplTest.java
@@ -105,6 +105,16 @@ class SummaryServiceImplTest implements WithAssertions {
   }
 
   @Test
+  @DisplayName("artistCollector is called to get recently followed artists")
+  void test_artist_collector_recently_artists() {
+    // when
+    underTest.createSummaryResponse();
+
+    // then
+    verify(artistCollector, times(1)).collectRecentlyFollowedArtists();
+  }
+
+  @Test
   @DisplayName("upcoming releases are returned")
   void test_upcoming_releases_returned() {
     // given
@@ -159,5 +169,19 @@ class SummaryServiceImplTest implements WithAssertions {
 
     // then
     assertThat(result.getMostExpectedReleases()).isEqualTo(releases);
+  }
+
+  @Test
+  @DisplayName("")
+  void test_most_recently_followed_artists_returned() {
+    // given
+    var artists = List.of(ArtistDtoFactory.createDefault());
+    doReturn(artists).when(artistCollector).collectRecentlyFollowedArtists();
+
+    // when
+    var result = underTest.createSummaryResponse();
+
+    // then
+    assertThat(result.getRecentlyFollowedArtists()).isEqualTo(artists);
   }
 }

--- a/webapp/src/test/java/rocks/metaldetector/testutil/DtoFactory.java
+++ b/webapp/src/test/java/rocks/metaldetector/testutil/DtoFactory.java
@@ -245,6 +245,7 @@ public class DtoFactory {
           .artistName(name)
           .externalId("1")
           .source("Discogs")
+          .follower(666)
           .build();
     }
   }


### PR DESCRIPTION
The recently followed artists are now shown on the homepage. The SummaryService's mock is deactivated and the number of followers added to the community's favorite artists.
It might be good to activate the mock also for the "default" profile, as we probably won't have that much content locally so the homepage looks quite barren. What do you think?