### PR TITLE
Spotify token refreshing

### DIFF
--- a/persistence/src/main/java/rocks/metaldetector/persistence/domain/spotify/SpotifyAuthorizationEntity.java
+++ b/persistence/src/main/java/rocks/metaldetector/persistence/domain/spotify/SpotifyAuthorizationEntity.java
@@ -1,8 +1,10 @@
 package rocks.metaldetector.persistence.domain.spotify;
 
 import lombok.AccessLevel;
-import lombok.EqualsAndHashCode;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import rocks.metaldetector.persistence.domain.BaseEntity;
 import rocks.metaldetector.persistence.domain.user.UserEntity;
@@ -13,6 +15,8 @@ import javax.persistence.OneToOne;
 
 @Data
 @NoArgsConstructor(access = AccessLevel.PROTECTED) // for hibernate and model mapper
+@AllArgsConstructor(access = AccessLevel.PRIVATE) // for lombok builder
+@Builder
 @EqualsAndHashCode(callSuper = true)
 @Entity(name = "spotifyAuthorizations")
 public class SpotifyAuthorizationEntity extends BaseEntity {

--- a/spotify/src/main/java/rocks/metaldetector/spotify/client/SpotifyAuthorizationClient.java
+++ b/spotify/src/main/java/rocks/metaldetector/spotify/client/SpotifyAuthorizationClient.java
@@ -7,4 +7,6 @@ public interface SpotifyAuthorizationClient {
   String getAppAuthorizationToken();
 
   SpotifyUserAuthorizationResponse getUserAuthorizationToken(String code);
+
+  SpotifyUserAuthorizationResponse refreshUserAuthorizationToken(String refreshToken);
 }

--- a/spotify/src/main/java/rocks/metaldetector/spotify/client/SpotifyAuthorizationClientImpl.java
+++ b/spotify/src/main/java/rocks/metaldetector/spotify/client/SpotifyAuthorizationClientImpl.java
@@ -35,8 +35,10 @@ public class SpotifyAuthorizationClientImpl implements SpotifyAuthorizationClien
   static final String GRANT_TYPE_KEY = "grant_type";
   static final String CODE_REQUEST_KEY = "code";
   static final String REDIRECT_URI_KEY = "redirect_uri";
+  static final String REFRESH_TOKEN_KEY = "refresh_token";
   static final String APP_AUTH_REQUEST_VALUE = "client_credentials";
   static final String USER_AUTH_REQUEST_VALUE = "authorization_code";
+  static final String USER_REFRESH_AUTH_REQUEST_VALUE = "refresh_token";
   static final String AUTHORIZATION_HEADER_PREFIX = "Basic ";
 
   private final RestTemplate spotifyRestTemplate;
@@ -68,17 +70,16 @@ public class SpotifyAuthorizationClientImpl implements SpotifyAuthorizationClien
     request.add(CODE_REQUEST_KEY, code);
     request.add(REDIRECT_URI_KEY, URLEncoder.encode(spotifyProperties.getApplicationHostUrl() + Endpoints.Frontend.PROFILE + Endpoints.Frontend.SPOTIFY_CALLBACK, Charset.defaultCharset()));
 
-    HttpEntity<MultiValueMap<String, String>> httpEntity = createHttpEntity(request);
-    ResponseEntity<SpotifyUserAuthorizationResponse> responseEntity = spotifyRestTemplate.postForEntity(
-        spotifyProperties.getAuthenticationBaseUrl() + AUTHORIZATION_ENDPOINT, httpEntity, SpotifyUserAuthorizationResponse.class);
+    return callAuthorizationEndpoint(request);
+  }
 
-    SpotifyUserAuthorizationResponse resultContainer = responseEntity.getBody();
-    var shouldNotHappen = resultContainer == null || !responseEntity.getStatusCode().is2xxSuccessful();
-    if (shouldNotHappen) {
-      throw new ExternalServiceException("Could not get user authorization token from Spotify (Response code: " + responseEntity.getStatusCode() + ")");
-    }
+  @Override
+  public SpotifyUserAuthorizationResponse refreshUserAuthorizationToken(String refreshToken) {
+    MultiValueMap<String, String> request = new LinkedMultiValueMap<>();
+    request.add(GRANT_TYPE_KEY, USER_REFRESH_AUTH_REQUEST_VALUE);
+    request.add(REFRESH_TOKEN_KEY, refreshToken);
 
-    return resultContainer;
+    return callAuthorizationEndpoint(request);
   }
 
   private HttpEntity<MultiValueMap<String, String>> createHttpEntity(MultiValueMap<String, String> request) {
@@ -92,5 +93,19 @@ public class SpotifyAuthorizationClientImpl implements SpotifyAuthorizationClien
 
   private String createAuthorizationHeader() {
     return AUTHORIZATION_HEADER_PREFIX + Base64.encodeBase64String((spotifyProperties.getClientId() + ":" + spotifyProperties.getClientSecret()).getBytes());
+  }
+
+  private SpotifyUserAuthorizationResponse callAuthorizationEndpoint(MultiValueMap<String, String> request) {
+    HttpEntity<MultiValueMap<String, String>> httpEntity = createHttpEntity(request);
+    ResponseEntity<SpotifyUserAuthorizationResponse> responseEntity = spotifyRestTemplate.postForEntity(
+        spotifyProperties.getAuthenticationBaseUrl() + AUTHORIZATION_ENDPOINT, httpEntity, SpotifyUserAuthorizationResponse.class);
+
+    SpotifyUserAuthorizationResponse resultContainer = responseEntity.getBody();
+    var shouldNotHappen = resultContainer == null || !responseEntity.getStatusCode().is2xxSuccessful();
+    if (shouldNotHappen) {
+      throw new ExternalServiceException("Could not get user authorization token from Spotify (Response code: " + responseEntity.getStatusCode() + ")");
+    }
+
+    return resultContainer;
   }
 }

--- a/spotify/src/main/java/rocks/metaldetector/spotify/client/SpotifyAuthorizationClientMock.java
+++ b/spotify/src/main/java/rocks/metaldetector/spotify/client/SpotifyAuthorizationClientMock.java
@@ -29,4 +29,14 @@ public class SpotifyAuthorizationClientMock implements SpotifyAuthorizationClien
         .scope("everything")
         .build();
   }
+
+  @Override
+  public SpotifyUserAuthorizationResponse refreshUserAuthorizationToken(String refreshToken) {
+    return SpotifyUserAuthorizationResponse.builder()
+        .accessToken(MOCK_TOKEN)
+        .tokenType("type")
+        .expiresIn(3600)
+        .scope("everything")
+        .build();
+  }
 }

--- a/spotify/src/main/java/rocks/metaldetector/spotify/facade/SpotifyService.java
+++ b/spotify/src/main/java/rocks/metaldetector/spotify/facade/SpotifyService.java
@@ -13,4 +13,6 @@ public interface SpotifyService {
   String getSpotifyAuthorizationUrl();
 
   SpotifyUserAuthorizationDto getAccessToken(String code);
+
+  SpotifyUserAuthorizationDto refreshToken(String refreshToken);
 }

--- a/spotify/src/main/java/rocks/metaldetector/spotify/facade/SpotifyServiceImpl.java
+++ b/spotify/src/main/java/rocks/metaldetector/spotify/facade/SpotifyServiceImpl.java
@@ -62,4 +62,10 @@ public class SpotifyServiceImpl implements SpotifyService {
     SpotifyUserAuthorizationResponse response = spotifyAuthorizationClient.getUserAuthorizationToken(code);
     return spotifyUserAuthorizationTransformer.transform(response);
   }
+
+  @Override
+  public SpotifyUserAuthorizationDto refreshToken(String refreshToken) {
+    SpotifyUserAuthorizationResponse response = spotifyAuthorizationClient.refreshUserAuthorizationToken(refreshToken);
+    return spotifyUserAuthorizationTransformer.transform(response);
+  }
 }

--- a/spotify/src/test/java/rocks/metaldetector/spotify/client/SpotifyAuthorizationClientImplTest.java
+++ b/spotify/src/test/java/rocks/metaldetector/spotify/client/SpotifyAuthorizationClientImplTest.java
@@ -48,7 +48,9 @@ import static rocks.metaldetector.spotify.client.SpotifyAuthorizationClientImpl.
 import static rocks.metaldetector.spotify.client.SpotifyAuthorizationClientImpl.CODE_REQUEST_KEY;
 import static rocks.metaldetector.spotify.client.SpotifyAuthorizationClientImpl.GRANT_TYPE_KEY;
 import static rocks.metaldetector.spotify.client.SpotifyAuthorizationClientImpl.REDIRECT_URI_KEY;
+import static rocks.metaldetector.spotify.client.SpotifyAuthorizationClientImpl.REFRESH_TOKEN_KEY;
 import static rocks.metaldetector.spotify.client.SpotifyAuthorizationClientImpl.USER_AUTH_REQUEST_VALUE;
+import static rocks.metaldetector.spotify.client.SpotifyAuthorizationClientImpl.USER_REFRESH_AUTH_REQUEST_VALUE;
 import static rocks.metaldetector.spotify.client.SpotifyDtoFactory.SpotifyAppAuthenticationResponseFactory;
 
 @ExtendWith(MockitoExtension.class)
@@ -220,7 +222,7 @@ class SpotifyAuthorizationClientImplTest implements WithAssertions {
 
     @Test
     @DisplayName("a POST call is made on spotify authorization endpoint")
-    void test() {
+    void test_correct_url_called() {
       // given
       var baseUrl = "baseUrl";
       doReturn(baseUrl).when(spotifyProperties).getAuthenticationBaseUrl();
@@ -240,7 +242,7 @@ class SpotifyAuthorizationClientImplTest implements WithAssertions {
       // given
       var code = "code";
       var host = "host";
-      var expectedRedirectUri = host + "%2Fprofile%2Fspotify-callback";;
+      var expectedRedirectUri = host + "%2Fprofile%2Fspotify-callback";
       SpotifyUserAuthorizationResponse responseMock = SpotfiyUserAuthorizationResponseFactory.createDefault();
       doReturn(ResponseEntity.ok(responseMock)).when(restTemplate).postForEntity(anyString(), any(), any());
       doReturn(host).when(spotifyProperties).getApplicationHostUrl();
@@ -303,14 +305,14 @@ class SpotifyAuthorizationClientImplTest implements WithAssertions {
     @DisplayName("correct response type is requested")
     void test_correct_response_type() {
       // given
-      SpotifyAppAuthorizationResponse responseMock = SpotifyAppAuthenticationResponseFactory.createDefault();
+      SpotifyUserAuthorizationResponse responseMock = SpotfiyUserAuthorizationResponseFactory.createDefault();
       doReturn(ResponseEntity.ok(responseMock)).when(restTemplate).postForEntity(anyString(), any(), any());
 
       // when
-      underTest.getAppAuthorizationToken();
+      underTest.getUserAuthorizationToken("code");
 
       // then
-      verify(restTemplate, times(1)).postForEntity(anyString(), any(), eq(SpotifyAppAuthorizationResponse.class));
+      verify(restTemplate, times(1)).postForEntity(anyString(), any(), eq(SpotifyUserAuthorizationResponse.class));
     }
 
     @Test
@@ -350,6 +352,149 @@ class SpotifyAuthorizationClientImplTest implements WithAssertions {
 
       // when
       Throwable throwable = catchThrowable(() -> underTest.getUserAuthorizationToken("code"));
+
+      // then
+      assertThat(throwable).isInstanceOf(ExternalServiceException.class);
+    }
+
+    private Stream<Arguments> httpStatusCodeProvider() {
+      return Stream.of(HttpStatus.values()).filter(status -> !status.is2xxSuccessful()).map(Arguments::of);
+    }
+  }
+
+  @Nested
+  @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+  @DisplayName("Tests for refreshing user authentication")
+  class RefreshUserAuthorizationTest {
+
+    @Test
+    @DisplayName("a POST call is made on spotify authorization endpoint")
+    void test_correct_url_called() {
+      // given
+      var baseUrl = "baseUrl";
+      doReturn(baseUrl).when(spotifyProperties).getAuthenticationBaseUrl();
+      SpotifyUserAuthorizationResponse responseMock = SpotfiyUserAuthorizationResponseFactory.createDefault();
+      doReturn(ResponseEntity.ok(responseMock)).when(restTemplate).postForEntity(anyString(), any(), any());
+
+      // when
+      underTest.refreshUserAuthorizationToken("refreshToken");
+
+      // then
+      verify(restTemplate, times(1)).postForEntity(eq(baseUrl + AUTHORIZATION_ENDPOINT), any(), any());
+    }
+
+    @Test
+    @DisplayName("correct request body is set")
+    void test_correct_request_body() {
+      // given
+      var refreshToken = "refreshToken";
+      SpotifyUserAuthorizationResponse responseMock = SpotfiyUserAuthorizationResponseFactory.createDefault();
+      doReturn(ResponseEntity.ok(responseMock)).when(restTemplate).postForEntity(anyString(), any(), any());
+
+      // when
+      underTest.refreshUserAuthorizationToken(refreshToken);
+
+      // then
+      verify(restTemplate, times(1)).postForEntity(anyString(), argumentCaptor.capture(), any());
+      HttpEntity<MultiValueMap<String, String>> httpEntity = argumentCaptor.getValue();
+      assertThat(httpEntity.getBody()).isNotNull();
+      assertThat(httpEntity.getBody().size()).isEqualTo(2);
+      assertThat(httpEntity.getBody().get(GRANT_TYPE_KEY)).isEqualTo(List.of(USER_REFRESH_AUTH_REQUEST_VALUE));
+      assertThat(httpEntity.getBody().get(REFRESH_TOKEN_KEY)).isEqualTo(List.of(refreshToken));
+    }
+
+    @Test
+    @DisplayName("correct standard headers are set")
+    void test_correct_standard_headers() {
+      // given
+      SpotifyUserAuthorizationResponse responseMock = SpotfiyUserAuthorizationResponseFactory.createDefault();
+      doReturn(ResponseEntity.ok(responseMock)).when(restTemplate).postForEntity(anyString(), any(), any());
+
+      // when
+      underTest.refreshUserAuthorizationToken("refreshToken");
+
+      // then
+      verify(restTemplate, times(1)).postForEntity(anyString(), argumentCaptor.capture(), any());
+      HttpEntity<MultiValueMap<String, String>> httpEntity = argumentCaptor.getValue();
+      HttpHeaders headers = httpEntity.getHeaders();
+      assertThat(headers.getContentType()).isEqualTo(MediaType.APPLICATION_FORM_URLENCODED);
+      assertThat(headers.getAccept()).isEqualTo(Collections.singletonList(MediaType.APPLICATION_JSON));
+      assertThat(headers.getAcceptCharset()).isEqualTo(Collections.singletonList(Charset.defaultCharset()));
+    }
+
+    @Test
+    @DisplayName("correct authorization header is set")
+    void test_correct_authorization_header() {
+      // given
+      var clientId = "clientId";
+      doReturn(clientId).when(spotifyProperties).getClientId();
+      var clientSecret = "clientSecret";
+      doReturn(clientSecret).when(spotifyProperties).getClientSecret();
+      var expectedAuthorizationHeader = AUTHORIZATION_HEADER_PREFIX + Base64.encodeBase64String((clientId + ":" + clientSecret).getBytes());
+      SpotifyUserAuthorizationResponse responseMock = SpotfiyUserAuthorizationResponseFactory.createDefault();
+      doReturn(ResponseEntity.ok(responseMock)).when(restTemplate).postForEntity(anyString(), any(), any());
+
+      // when
+      underTest.refreshUserAuthorizationToken("refreshToken");
+
+      // then
+      verify(restTemplate, times(1)).postForEntity(anyString(), argumentCaptor.capture(), any());
+      HttpEntity<MultiValueMap<String, String>> httpEntity = argumentCaptor.getValue();
+      HttpHeaders headers = httpEntity.getHeaders();
+      assertThat(headers.get(AUTHORIZATION)).isEqualTo(List.of(expectedAuthorizationHeader));
+    }
+
+    @Test
+    @DisplayName("correct response type is requested")
+    void test_correct_response_type() {
+      // given
+      SpotifyUserAuthorizationResponse responseMock = SpotfiyUserAuthorizationResponseFactory.createDefault();
+      doReturn(ResponseEntity.ok(responseMock)).when(restTemplate).postForEntity(anyString(), any(), any());
+
+      // when
+      underTest.refreshUserAuthorizationToken("refreshToken");
+
+      // then
+      verify(restTemplate, times(1)).postForEntity(anyString(), any(), eq(SpotifyUserAuthorizationResponse.class));
+    }
+
+    @Test
+    @DisplayName("SpotifyUserAuthorizationResponse is returned")
+    void test_return_value() {
+      // given
+      SpotifyUserAuthorizationResponse responseMock = SpotfiyUserAuthorizationResponseFactory.createDefault();
+      doReturn(ResponseEntity.ok(responseMock)).when(restTemplate).postForEntity(anyString(), any(), any());
+
+      // when
+      var result = underTest.refreshUserAuthorizationToken("refreshToken");
+
+      // then
+      assertThat(result).isEqualTo(responseMock);
+    }
+
+    @Test
+    @DisplayName("if the response is null, an ExternalServiceException is thrown")
+    void test_exception_if_response_is_null() {
+      // given
+      doReturn(ResponseEntity.ok(null)).when(restTemplate).postForEntity(anyString(), any(), any());
+
+      // when
+      Throwable throwable = catchThrowable(() -> underTest.refreshUserAuthorizationToken("refreshToken"));
+
+      // then
+      assertThat(throwable).isInstanceOf(ExternalServiceException.class);
+    }
+
+    @ParameterizedTest(name = "if the status is {0}, an ExternalServiceException is thrown")
+    @MethodSource("httpStatusCodeProvider")
+    @DisplayName("if the status code is not OK, an ExternalServiceException is thrown")
+    void test_exception_if_status_is_not_ok(HttpStatus httpStatus) {
+      // given
+      SpotifyUserAuthorizationResponse responseMock = SpotfiyUserAuthorizationResponseFactory.createDefault();
+      doReturn(ResponseEntity.status(httpStatus).body(responseMock)).when(restTemplate).postForEntity(anyString(), any(), any());
+
+      // when
+      Throwable throwable = catchThrowable(() -> underTest.refreshUserAuthorizationToken("refreshToken"));
 
       // then
       assertThat(throwable).isInstanceOf(ExternalServiceException.class);

--- a/spotify/src/test/java/rocks/metaldetector/spotify/client/SpotifyAuthorizationClientMockTest.java
+++ b/spotify/src/test/java/rocks/metaldetector/spotify/client/SpotifyAuthorizationClientMockTest.java
@@ -3,12 +3,9 @@ package rocks.metaldetector.spotify.client;
 import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.junit.jupiter.MockitoExtension;
 
 import static rocks.metaldetector.spotify.client.SpotifyAuthorizationClientMock.MOCK_TOKEN;
 
-@ExtendWith(MockitoExtension.class)
 class SpotifyAuthorizationClientMockTest implements WithAssertions {
 
   private SpotifyAuthorizationClientMock underTest = new SpotifyAuthorizationClientMock();
@@ -26,11 +23,18 @@ class SpotifyAuthorizationClientMockTest implements WithAssertions {
   @Test
   @DisplayName("getUserAuthenticationToken: should return mock response")
   void test_get_user_auth_response() {
-    // given
-    var code = "code";
-
     // when
-    var result = underTest.getUserAuthorizationToken(code);
+    var result = underTest.getUserAuthorizationToken("code");
+
+    // then
+    assertThat(result).isNotNull();
+  }
+
+  @Test
+  @DisplayName("getUserAuthenticationToken: should return mock response")
+  void test_refresh_user_auth() {
+    // when
+    var result = underTest.refreshUserAuthorizationToken("refreshToken");
 
     // then
     assertThat(result).isNotNull();

--- a/spotify/src/test/java/rocks/metaldetector/spotify/facade/SpotifyServiceImplTest.java
+++ b/spotify/src/test/java/rocks/metaldetector/spotify/facade/SpotifyServiceImplTest.java
@@ -294,7 +294,7 @@ class SpotifyServiceImplTest implements WithAssertions {
       doReturn(response).when(authenticationClient).getUserAuthorizationToken(anyString());
 
       // when
-      var result = underTest.getAccessToken("code");
+      underTest.getAccessToken("code");
 
       // then
       verify(userAuthorizationTransformer, times(1)).transform(response);
@@ -309,6 +309,52 @@ class SpotifyServiceImplTest implements WithAssertions {
 
       // when
       var result = underTest.getAccessToken("code");
+
+      // then
+      assertThat(result).isEqualTo(userAuthorizationDto);
+    }
+  }
+
+  @Nested
+  @DisplayName("Tests for method refreshToken")
+  class RefreshAccessTokenTest {
+
+    @Test
+    @DisplayName("spotifyAuthenticationClient is called")
+    void test_authentication_client_called() {
+      // given
+      var refreshToken = "refreshToken";
+
+      // when
+      underTest.refreshToken(refreshToken);
+
+      // then
+      verify(authenticationClient, times(1)).refreshUserAuthorizationToken(refreshToken);
+    }
+
+    @Test
+    @DisplayName("userAuthorizationTransformer is called")
+    void test_user_authorization_transformer_called() {
+      // given
+      var response = SpotfiyUserAuthorizationResponseFactory.createDefault();
+      doReturn(response).when(authenticationClient).refreshUserAuthorizationToken(anyString());
+
+      // when
+      underTest.refreshToken("refreshToken");
+
+      // then
+      verify(userAuthorizationTransformer, times(1)).transform(response);
+    }
+
+    @Test
+    @DisplayName("result is returned")
+    void test_result_is_returned() {
+      // given
+      var userAuthorizationDto = SpotfiyUserAuthorizationDtoFactory.createDefault();
+      doReturn(userAuthorizationDto).when(userAuthorizationTransformer).transform(any());
+
+      // when
+      var result = underTest.refreshToken("refreshToken");
 
       // then
       assertThat(result).isEqualTo(userAuthorizationDto);

--- a/webapp/src/main/java/rocks/metaldetector/service/spotify/SpotifyUserAuthorizationService.java
+++ b/webapp/src/main/java/rocks/metaldetector/service/spotify/SpotifyUserAuthorizationService.java
@@ -4,5 +4,7 @@ public interface SpotifyUserAuthorizationService {
 
   String prepareAuthorization();
 
-  void fetchToken(String state, String code);
+  void fetchInitialToken(String state, String code);
+
+  String getOrRefreshToken();
 }

--- a/webapp/src/main/java/rocks/metaldetector/web/controller/mvc/ProfileController.java
+++ b/webapp/src/main/java/rocks/metaldetector/web/controller/mvc/ProfileController.java
@@ -25,7 +25,7 @@ public class ProfileController {
   @GetMapping(path = Endpoints.Frontend.SPOTIFY_CALLBACK)
   public ModelAndView showProfile(@RequestParam(value = "code") String code,
                                   @RequestParam(value = "state") String state) {
-    spotifyUserAuthorizationService.fetchToken(state, code);
+    spotifyUserAuthorizationService.fetchInitialToken(state, code);
     return new ModelAndView(ViewNames.Frontend.PROFILE);
   }
 }

--- a/webapp/src/test/java/rocks/metaldetector/web/controller/mvc/ProfileControllerTest.java
+++ b/webapp/src/test/java/rocks/metaldetector/web/controller/mvc/ProfileControllerTest.java
@@ -111,6 +111,6 @@ class ProfileControllerTest {
     callbackRestAssuredUtils.doGet(parameter);
 
     // then
-    verify(userAuthorizationService, times(1)).fetchToken(state, code);
+    verify(userAuthorizationService, times(1)).fetchInitialToken(state, code);
   }
 }


### PR DESCRIPTION
The `SpotifyUserAuthorizationService` now provides a method that returns the access token for the current user and refreshes it if necessary.