### PR TITLE
Spotify token is automatically refreshed on import if expired

### DIFF
--- a/webapp/src/main/java/rocks/metaldetector/service/spotify/SpotifyArtistImportServiceImpl.java
+++ b/webapp/src/main/java/rocks/metaldetector/service/spotify/SpotifyArtistImportServiceImpl.java
@@ -2,16 +2,12 @@ package rocks.metaldetector.service.spotify;
 
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
-import rocks.metaldetector.persistence.domain.user.UserEntity;
-import rocks.metaldetector.persistence.domain.user.UserRepository;
-import rocks.metaldetector.security.CurrentPublicUserIdSupplier;
 import rocks.metaldetector.service.artist.ArtistDto;
 import rocks.metaldetector.service.artist.ArtistService;
 import rocks.metaldetector.service.artist.FollowArtistService;
 import rocks.metaldetector.spotify.facade.SpotifyService;
 import rocks.metaldetector.spotify.facade.dto.SpotifyAlbumDto;
 import rocks.metaldetector.spotify.facade.dto.SpotifyArtistDto;
-import rocks.metaldetector.support.exceptions.ResourceNotFoundException;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -23,19 +19,15 @@ import static rocks.metaldetector.persistence.domain.artist.ArtistSource.SPOTIFY
 public class SpotifyArtistImportServiceImpl implements SpotifyArtistImportService {
 
   private final SpotifyService spotifyService;
-  private final CurrentPublicUserIdSupplier currentPublicUserIdSupplier;
-  private final UserRepository userRepository;
   private final FollowArtistService followArtistService;
   private final ArtistService artistService;
+  private final SpotifyUserAuthorizationService userAuthorizationService;
 
   @Override
   public List<ArtistDto> importArtistsFromLikedReleases() {
-    String publicUserId = currentPublicUserIdSupplier.get();
-    UserEntity currentUser = userRepository.findByPublicId(publicUserId).orElseThrow(
-        () -> new ResourceNotFoundException("User with public id '" + publicUserId + "' not found!")
-    );
+    String spotifyAccessToken = userAuthorizationService.getOrRefreshToken();
 
-    List<SpotifyAlbumDto> importedAlbums = spotifyService.fetchLikedAlbums(currentUser.getSpotifyAuthorization().getAccessToken());
+    List<SpotifyAlbumDto> importedAlbums = spotifyService.fetchLikedAlbums(spotifyAccessToken);
     List<String> artistIds = importedAlbums.stream()
         .flatMap(album -> album.getArtists().stream())
         .map(SpotifyArtistDto::getId)


### PR DESCRIPTION
I also removed the times(1) in the test class as we discussed because the normal verify() call with times(1) anyway. Another PR for the rest follows.