### PR TITLE
Dependency updates and pom cleanups

### DIFF
--- a/butler/pom.xml
+++ b/butler/pom.xml
@@ -14,14 +14,15 @@
     <version>0.0.1</version>
     <name>metal-detector-butler</name>
 
-    <properties>
-        <java.version>15</java.version>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
+            <scope>test</scope>
         </dependency>
 
         <dependency>

--- a/discogs/pom.xml
+++ b/discogs/pom.xml
@@ -14,10 +14,6 @@
     <version>0.0.1</version>
     <name>metal-detector-discogs</name>
 
-    <properties>
-        <java.version>15</java.version>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/persistence/pom.xml
+++ b/persistence/pom.xml
@@ -14,10 +14,6 @@
     <version>0.0.1</version>
     <name>metal-detector-persistence</name>
 
-    <properties>
-        <java.version>15</java.version>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -28,7 +24,6 @@
             <artifactId>postgresql</artifactId>
         </dependency>
 
-        <!-- Project Modules -->
         <dependency>
             <groupId>rocks.metal-detector</groupId>
             <artifactId>metal-detector-support</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.3.4.RELEASE</version>
+        <version>2.3.5.RELEASE</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
@@ -50,8 +50,7 @@
     </developers>
 
     <properties>
-        <jsonwebtoken.version>0.9.1</jsonwebtoken.version>
-        <modelmapper.version>2.3.8</modelmapper.version>
+        <java.version>15</java.version>
         <junit-jupiter.version>5.7.0</junit-jupiter.version>
         <mockito.version>3.1.0</mockito.version>
         <coveralls-plugin.version>4.3.0</coveralls-plugin.version>
@@ -65,20 +64,11 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-cache</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.ehcache</groupId>
-            <artifactId>ehcache</artifactId>
-        </dependency>
 
         <!-- Security -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-security</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.jsonwebtoken</groupId>
-            <artifactId>jjwt</artifactId>
-            <version>${jsonwebtoken.version}</version>
         </dependency>
 
         <!-- Util -->
@@ -99,16 +89,6 @@
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.modelmapper</groupId>
-            <artifactId>modelmapper</artifactId>
-            <version>${modelmapper.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-text</artifactId>
-            <version>${apache-commons-text.version}</version>
         </dependency>
 
 
@@ -153,6 +133,16 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-text</artifactId>
+                <version>${apache-commons-text.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <build>
         <plugins>

--- a/spotify/pom.xml
+++ b/spotify/pom.xml
@@ -14,15 +14,12 @@
     <version>0.0.1</version>
     <name>metal-detector-spotify</name>
 
-    <properties>
-        <java.version>15</java.version>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
+
         <dependency>
             <groupId>rocks.metal-detector</groupId>
             <artifactId>metal-detector-support</artifactId>

--- a/support/pom.xml
+++ b/support/pom.xml
@@ -15,13 +15,22 @@
     <name>metal-detector-support</name>
 
     <properties>
-        <java.version>15</java.version>
+        <jsonwebtoken.version>0.9.1</jsonwebtoken.version>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt</artifactId>
+            <version>${jsonwebtoken.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
         </dependency>
     </dependencies>
 

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -15,17 +15,17 @@
     <name>metal-detector-webapp</name>
 
     <properties>
-        <java.version>15</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <hibernate-validator.version>6.1.5.Final</hibernate-validator.version>
+        <hibernate-validator.version>6.1.6.Final</hibernate-validator.version>
         <validation-api.version>2.0.1.Final</validation-api.version>
         <material-icons.version>0.3.1</material-icons.version>
         <rest-assured.version>4.2.0</rest-assured.version>
-        <bootstrap.version>4.5.2</bootstrap.version>
+        <bootstrap.version>4.5.3</bootstrap.version>
         <datatables.version>1.10.21</datatables.version>
         <thymeleaf-dialect.version>2.5.1</thymeleaf-dialect.version>
         <apache-commons-lang3.version>3.11</apache-commons-lang3.version>
+        <modelmapper.version>2.3.8</modelmapper.version>
     </properties>
 
     <dependencies>
@@ -101,21 +101,25 @@
         <dependency>
             <groupId>org.webjars</groupId>
             <artifactId>webjars-locator-core</artifactId>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>org.webjars</groupId>
             <artifactId>bootstrap</artifactId>
             <version>${bootstrap.version}</version>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>org.webjars.npm</groupId>
             <artifactId>material-icons</artifactId>
             <version>${material-icons.version}</version>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>org.webjars</groupId>
             <artifactId>datatables</artifactId>
             <version>${datatables.version}</version>
+            <scope>runtime</scope>
         </dependency>
 
         <!-- Project Modules -->
@@ -150,6 +154,15 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <version>${apache-commons-lang3.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.modelmapper</groupId>
+            <artifactId>modelmapper</artifactId>
+            <version>${modelmapper.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.ehcache</groupId>
+            <artifactId>ehcache</artifactId>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Some dependency updates and pom reworks. I removed some dependencies from the root level and put them only into the modules where they are needed. I also edited some scopes for jars that are only needed at runtime.
I found one more reason to migrate to gradle here: Because the support-module is referenced in all other modules it's transitive dependencies "leak" into the other modules. In gradle it would be possible to declare these dependencies as 'implementation' so this would not happen. As far as I know this is not possible in maven.