### PR TITLE
Endpoint to follow multiple spotify artists

### DIFF
--- a/webapp/src/main/java/rocks/metaldetector/service/artist/FollowArtistService.java
+++ b/webapp/src/main/java/rocks/metaldetector/service/artist/FollowArtistService.java
@@ -8,6 +8,8 @@ public interface FollowArtistService {
 
   void follow(String externalArtistId, ArtistSource source);
 
+  void followSpotifyArtists(List<String> spotifyArtistIds);
+
   void unfollow(String externalArtistId, ArtistSource source);
 
   boolean isCurrentUserFollowing(String externalArtistId, ArtistSource source);

--- a/webapp/src/main/java/rocks/metaldetector/service/artist/FollowArtistServiceImpl.java
+++ b/webapp/src/main/java/rocks/metaldetector/service/artist/FollowArtistServiceImpl.java
@@ -122,8 +122,8 @@ public class FollowArtistServiceImpl implements FollowArtistService {
 
   private List<ArtistEntity> saveAndFetchArtists(List<String> spotifyArtistIds) {
     List<String> newArtistsIds = artistService.findNewArtistIds(spotifyArtistIds);
-    List<SpotifyArtistDto> spotifyArtistDtos = spotifyService.searchArtistsByIds(newArtistsIds);
-    artistService.persistArtists(spotifyArtistDtos);
+    List<SpotifyArtistDto> newSpotifyArtistDtos = spotifyService.searchArtistsByIds(newArtistsIds);
+    artistService.persistArtists(newSpotifyArtistDtos);
     return artistRepository.findAllByExternalIdIn(spotifyArtistIds);
   }
 

--- a/webapp/src/main/java/rocks/metaldetector/web/api/request/FollowSpotifyArtistsRequest.java
+++ b/webapp/src/main/java/rocks/metaldetector/web/api/request/FollowSpotifyArtistsRequest.java
@@ -1,0 +1,19 @@
+package rocks.metaldetector.web.api.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotEmpty;
+import java.util.List;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class FollowSpotifyArtistsRequest {
+
+  @NotEmpty
+  private List<String> spotifyArtistIds;
+}

--- a/webapp/src/main/java/rocks/metaldetector/web/controller/rest/ArtistsRestController.java
+++ b/webapp/src/main/java/rocks/metaldetector/web/controller/rest/ArtistsRestController.java
@@ -7,6 +7,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -14,7 +15,10 @@ import rocks.metaldetector.persistence.domain.artist.ArtistSource;
 import rocks.metaldetector.service.artist.ArtistSearchService;
 import rocks.metaldetector.service.artist.FollowArtistService;
 import rocks.metaldetector.support.Endpoints;
+import rocks.metaldetector.web.api.request.FollowSpotifyArtistsRequest;
 import rocks.metaldetector.web.api.response.ArtistSearchResponse;
+
+import javax.validation.Valid;
 
 @RestController
 @RequestMapping(Endpoints.Rest.ARTISTS)
@@ -44,6 +48,12 @@ public class ArtistsRestController {
   @PostMapping(path = Endpoints.Rest.FOLLOW + "/{source}/{externalId}")
   public ResponseEntity<Void> handleFollow(@PathVariable String source, @PathVariable String externalId) {
     followArtistService.follow(externalId, ArtistSource.getArtistSourceFromString(source));
+    return ResponseEntity.ok().build();
+  }
+
+  @PostMapping(path = Endpoints.Rest.FOLLOW + "/spotify")
+  public ResponseEntity<Void> handleFollowSpotifyArtists(@Valid @RequestBody FollowSpotifyArtistsRequest request) {
+    followArtistService.followSpotifyArtists(request.getSpotifyArtistIds());
     return ResponseEntity.ok().build();
   }
 

--- a/webapp/src/test/java/rocks/metaldetector/service/artist/FollowArtistServiceImplTest.java
+++ b/webapp/src/test/java/rocks/metaldetector/service/artist/FollowArtistServiceImplTest.java
@@ -437,16 +437,11 @@ class FollowArtistServiceImplTest implements WithAssertions {
   @Test
   @DisplayName("Current user is fetched on follow multiple")
   void test_follow_multiple_should_get_current_user() {
-    // given
-    doReturn(PUBLIC_USER_ID).when(currentPublicUserIdSupplier).get();
-    doReturn(Optional.of(userEntity)).when(userRepository).findByPublicId(anyString());
-
     // when
     underTest.followSpotifyArtists(Collections.emptyList());
 
     // then
-    verify(currentPublicUserIdSupplier).get();
-    verify(userRepository).findByPublicId(PUBLIC_USER_ID);
+    verify(currentUserSupplier).get();
   }
 
   @Test
@@ -455,7 +450,7 @@ class FollowArtistServiceImplTest implements WithAssertions {
     // given
     var artistEntity = ArtistEntityFactory.withExternalId("a");
     var expectedFollowActionEntities = List.of(FollowActionEntity.builder().artist(artistEntity).user(userEntity).build());
-    doReturn(Optional.of(userEntity)).when(userRepository).findByPublicId(any());
+    doReturn(userEntity).when(currentUserSupplier).get();
     doReturn(List.of(artistEntity)).when(artistRepository).findAllByExternalIdIn(any());
 
     // when

--- a/webapp/src/test/java/rocks/metaldetector/web/controller/rest/ArtistsRestControllerTest.java
+++ b/webapp/src/test/java/rocks/metaldetector/web/controller/rest/ArtistsRestControllerTest.java
@@ -9,6 +9,9 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -21,10 +24,14 @@ import rocks.metaldetector.service.artist.FollowArtistService;
 import rocks.metaldetector.service.exceptions.RestExceptionsHandler;
 import rocks.metaldetector.support.Endpoints;
 import rocks.metaldetector.web.RestAssuredMockMvcUtils;
+import rocks.metaldetector.web.api.request.FollowSpotifyArtistsRequest;
 import rocks.metaldetector.web.api.response.ArtistSearchResponse;
 
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
@@ -177,11 +184,13 @@ class ArtistsRestControllerTest implements WithAssertions {
 
     private RestAssuredMockMvcUtils followArtistRestAssuredUtils;
     private RestAssuredMockMvcUtils unfollowArtistRestAssuredUtils;
+    private RestAssuredMockMvcUtils followSpotifyArtistsRestAssuredUtils;
 
     @BeforeEach
     void setUp() {
       followArtistRestAssuredUtils = new RestAssuredMockMvcUtils(Endpoints.Rest.ARTISTS + Endpoints.Rest.FOLLOW);
       unfollowArtistRestAssuredUtils = new RestAssuredMockMvcUtils(Endpoints.Rest.ARTISTS + Endpoints.Rest.UNFOLLOW);
+      followSpotifyArtistsRestAssuredUtils = new RestAssuredMockMvcUtils(Endpoints.Rest.ARTISTS + Endpoints.Rest.FOLLOW + "/spotify");
       RestAssuredMockMvc.standaloneSetup(underTest,
                                          springSecurity((request, response, chain) -> chain.doFilter(request, response)),
                                          RestExceptionsHandler.class);
@@ -270,6 +279,50 @@ class ArtistsRestControllerTest implements WithAssertions {
 
       // then
       result.status(HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    @DisplayName("Should return 200 when following spotify artists")
+    void handle_follow_multiple_return_200() {
+      // given
+      var request = FollowSpotifyArtistsRequest.builder().spotifyArtistIds(List.of("a")).build();
+
+      // when
+      var validatableResponse = followSpotifyArtistsRestAssuredUtils.doPost(request);
+
+      // then
+      validatableResponse.statusCode(HttpStatus.OK.value());
+    }
+
+    @Test
+    @DisplayName("Should call follow artist service when following artists")
+    void handle_follow_multiple_call_follow_artist_service() {
+      // given
+      var request = FollowSpotifyArtistsRequest.builder().spotifyArtistIds(List.of("a")).build();
+
+      // when
+      followSpotifyArtistsRestAssuredUtils.doPost(request);
+
+      // then
+      verify(followArtistService).followSpotifyArtists(request.getSpotifyArtistIds());
+    }
+
+    @ParameterizedTest(name = "request cannot be {0}")
+    @MethodSource("badRequestProvider")
+    @DisplayName("Should return bad request on invalid request")
+    void handle_follow_multiple_bad_request(FollowSpotifyArtistsRequest request) {
+      // when
+      var result = followSpotifyArtistsRestAssuredUtils.doPost(request);
+
+      // then
+      result.status(HttpStatus.BAD_REQUEST);
+    }
+
+    private Stream<Arguments> badRequestProvider() {
+      return Stream.of(
+          Arguments.of(FollowSpotifyArtistsRequest.builder().build()),
+          Arguments.of(FollowSpotifyArtistsRequest.builder().spotifyArtistIds(Collections.emptyList()).build())
+      );
     }
   }
 }


### PR DESCRIPTION
A new endpoint to follow multiple spotify artists. This endpoint fetched all artists from Spotify that are not yet in our database and then saves all FollowActionEntities for the current user.