### PR TITLE
Reduce javascript file size

### DIFF
--- a/webapp/src/main/resources/static/ts/package.json
+++ b/webapp/src/main/resources/static/ts/package.json
@@ -23,13 +23,12 @@
     "ts-loader": "^8.0.11",
     "typescript": "^4.1.2",
     "webpack": "^5.9.0",
-    "webpack-cli": "^4.2.0",
-    "webpack-dev-server": "^3.11.0"
+    "webpack-cli": "^4.2.0"
   },
   "dependencies": {
     "axios": "^0.21.0",
+    "dayjs": "^1.9.6",
     "faker": "^5.1.0",
-    "moment": "^2.27.0",
     "qs": "^6.9.4"
   }
 }

--- a/webapp/src/main/resources/static/ts/package.json
+++ b/webapp/src/main/resources/static/ts/package.json
@@ -2,30 +2,33 @@
   "name": "metal-detector-frondend",
   "version": "1.0.0",
   "description": "Metal Detector Frontend",
+  "repository": {
+    "url": "https://github.com/MetalDetectorRocks/metal-detector-main"
+  },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "compile": "tsc",
-    "start": "webpack-dev-server",
-    "dev-build": "webpack",
+    "update-dependencies": "npm-check -u",
+    "dev-build": "webpack --progress --watch --config webpack.config.dev.js",
     "prod-build": "webpack --config webpack.config.prod.js"
   },
   "keywords": [],
   "author": "Daniel Wagner",
   "license": "Apache-2.0",
   "devDependencies": {
-    "@types/node": "^14.0.22",
-    "@types/qs": "^6.9.3",
+    "@types/node": "^14.14.10",
+    "@types/qs": "^6.9.5",
     "@types/source-map": "^0.5.7",
     "clean-webpack-plugin": "^3.0.0",
-    "ts-loader": "^7.0.5",
-    "typescript": "^3.9.5",
-    "webpack": "^4.43.0",
-    "webpack-cli": "^3.3.12",
+    "ts-loader": "^8.0.11",
+    "typescript": "^4.1.2",
+    "webpack": "^5.9.0",
+    "webpack-cli": "^4.2.0",
     "webpack-dev-server": "^3.11.0"
   },
   "dependencies": {
-    "axios": "^0.19.2",
-    "faker": "^4.1.0",
+    "axios": "^0.21.0",
+    "faker": "^5.1.0",
     "moment": "^2.27.0",
     "qs": "^6.9.4"
   }

--- a/webapp/src/main/resources/static/ts/src/service/date-format-service.ts
+++ b/webapp/src/main/resources/static/ts/src/service/date-format-service.ts
@@ -1,16 +1,20 @@
-import moment from "moment";
+import relativeTime from "dayjs/plugin/relativeTime";
+import advancedFormat from "dayjs/plugin/advancedFormat";
+import dayjs from "dayjs";
 
 export class DateFormatService {
 
     constructor() {
+        dayjs.extend(relativeTime);
+        dayjs.extend(advancedFormat);
     }
 
     public formatRelative(dateStr: string): string {
-        return moment(dateStr).fromNow();
+        return dayjs(dateStr).fromNow();
     }
 
     public format(dateStr: string, dateFormat: DateFormat): string {
-        return moment(dateStr).format(dateFormat);
+        return dayjs(dateStr).format(dateFormat);
     }
 }
 

--- a/webapp/src/main/resources/static/ts/webpack.config.dev.js
+++ b/webapp/src/main/resources/static/ts/webpack.config.dev.js
@@ -1,4 +1,5 @@
 const path = require("path");
+const webpack = require('webpack');
 
 module.exports = {
     mode: "development",
@@ -9,7 +10,11 @@ module.exports = {
         homepage: "./src/bundles/homepage.ts",
         spotify_synchronization: "./src/bundles/spotify-synchronization.ts"
     },
-    watch: true,
+    watchOptions: {
+        aggregateTimeout: 200,
+        poll: 1000,
+        ignored: 'node_modules/**'
+    },
     output: {
         filename: "[name].bundle.js",
         path: path.resolve(__dirname, "dist"),

--- a/webapp/src/main/resources/static/ts/webpack.config.prod.js
+++ b/webapp/src/main/resources/static/ts/webpack.config.prod.js
@@ -1,4 +1,5 @@
 const path = require("path");
+const webpack = require('webpack');
 const CleanPlugin = require("clean-webpack-plugin");
 
 module.exports = {
@@ -14,7 +15,6 @@ module.exports = {
         filename: "[name].bundle.js",
         path: path.resolve(__dirname, "dist"),
     },
-    devtool: "none",
     module: {
         rules: [
             {


### PR DESCRIPTION
Since we use `moment.js`, the config for all locales (which are mostly translations) is generated in the bundles.
This makes the bundles very large (>300 KB).

This can be easily configured via Webpack. Nevertheless I decided to use a different lib because it is much smaller and has a similar feature set.

The new sizes in prod are as follows:
```
asset my_artists.bundle.js 40.9 KiB [emitted] [minimized] (name: my_artists)
asset releases.bundle.js 40.1 KiB [emitted] [minimized] (name: releases)
asset homepage.bundle.js 38 KiB [emitted] [minimized] (name: homepage)
asset search.bundle.js 34.7 KiB [emitted] [minimized] (name: search)
asset spotify_synchronization.bundle.js 30.8 KiB [emitted] [minimized] (name: spotify_synchronization)
```