### PR TITLE
expiresIn on SpotifyAuthorizationEntity is now expiresAt

### DIFF
--- a/persistence/src/main/java/rocks/metaldetector/persistence/domain/spotify/SpotifyAuthorizationEntity.java
+++ b/persistence/src/main/java/rocks/metaldetector/persistence/domain/spotify/SpotifyAuthorizationEntity.java
@@ -14,6 +14,7 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.JoinColumn;
 import javax.persistence.OneToOne;
+import java.time.LocalDateTime;
 
 @Data
 @NoArgsConstructor(access = AccessLevel.PROTECTED) // for hibernate and model mapper
@@ -38,8 +39,8 @@ public class SpotifyAuthorizationEntity extends BaseEntity {
   @Column(name = "token_type")
   private String tokenType;
 
-  @Column(name = "expires_in")
-  private Integer expiresIn;
+  @Column(name = "expires_at")
+  private LocalDateTime expiresAt;
 
   @OneToOne(targetEntity = UserEntity.class)
   @JoinColumn(nullable = false, name = "users_id")

--- a/webapp/src/main/java/rocks/metaldetector/service/spotify/SpotifyUserAuthorizationServiceImpl.java
+++ b/webapp/src/main/java/rocks/metaldetector/service/spotify/SpotifyUserAuthorizationServiceImpl.java
@@ -19,6 +19,7 @@ import java.util.Optional;
 public class SpotifyUserAuthorizationServiceImpl implements SpotifyUserAuthorizationService {
 
   static final int STATE_SIZE = 10;
+  static final int GRACE_PERIOD_SECONDS = 60;
 
   private final CurrentUserSupplier currentUserSupplier;
   private final SpotifyAuthorizationRepository spotifyAuthorizationRepository;
@@ -65,7 +66,7 @@ public class SpotifyUserAuthorizationServiceImpl implements SpotifyUserAuthoriza
     authorizationEntity.setRefreshToken(authorizationDto.getRefreshToken());
     authorizationEntity.setScope(authorizationDto.getScope());
     authorizationEntity.setTokenType(authorizationDto.getTokenType());
-    authorizationEntity.setExpiresAt(now.plusSeconds(authorizationDto.getExpiresIn()));
+    authorizationEntity.setExpiresAt(now.plusSeconds(authorizationDto.getExpiresIn() - GRACE_PERIOD_SECONDS));
 
     spotifyAuthorizationRepository.save(authorizationEntity);
   }
@@ -87,7 +88,7 @@ public class SpotifyUserAuthorizationServiceImpl implements SpotifyUserAuthoriza
     authorizationEntity.setAccessToken(refreshedToken.getAccessToken());
     authorizationEntity.setScope(refreshedToken.getScope());
     authorizationEntity.setTokenType(refreshedToken.getTokenType());
-    authorizationEntity.setExpiresAt(now.plusSeconds(refreshedToken.getExpiresIn()));
+    authorizationEntity.setExpiresAt(now.plusSeconds(refreshedToken.getExpiresIn() - GRACE_PERIOD_SECONDS));
     spotifyAuthorizationRepository.save(authorizationEntity);
 
     return refreshedToken.getAccessToken();

--- a/webapp/src/test/java/rocks/metaldetector/service/spotify/SpotifyUserAuthorizationServiceImplTest.java
+++ b/webapp/src/test/java/rocks/metaldetector/service/spotify/SpotifyUserAuthorizationServiceImplTest.java
@@ -38,6 +38,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
+import static rocks.metaldetector.service.spotify.SpotifyUserAuthorizationServiceImpl.GRACE_PERIOD_SECONDS;
 import static rocks.metaldetector.service.spotify.SpotifyUserAuthorizationServiceImpl.STATE_SIZE;
 
 @ExtendWith(MockitoExtension.class)
@@ -353,7 +354,7 @@ class SpotifyUserAuthorizationServiceImplTest implements WithAssertions {
       SpotifyAuthorizationEntity updatedAuthorization = argumentCaptor.getValue();
       assertThat(updatedAuthorization.getAccessToken()).isEqualTo(authorizationDto.getAccessToken());
       assertThat(updatedAuthorization.getRefreshToken()).isEqualTo(authorizationDto.getRefreshToken());
-      assertThat(updatedAuthorization.getExpiresAt()).isEqualTo(now.plusSeconds(authorizationDto.getExpiresIn()));
+      assertThat(updatedAuthorization.getExpiresAt()).isEqualTo(now.plusSeconds(authorizationDto.getExpiresIn() - GRACE_PERIOD_SECONDS));
       assertThat(updatedAuthorization.getScope()).isEqualTo(authorizationDto.getScope());
       assertThat(updatedAuthorization.getTokenType()).isEqualTo(authorizationDto.getTokenType());
     }
@@ -495,7 +496,7 @@ class SpotifyUserAuthorizationServiceImplTest implements WithAssertions {
       var updatedAuthorizationEntity = argumentCaptor.getValue();
       assertThat(updatedAuthorizationEntity.getAccessToken()).isEqualTo(authorizationDto.getAccessToken());
       assertThat(updatedAuthorizationEntity.getScope()).isEqualTo(authorizationDto.getScope());
-      assertThat(updatedAuthorizationEntity.getExpiresAt()).isEqualTo(now.plusSeconds(authorizationDto.getExpiresIn()));
+      assertThat(updatedAuthorizationEntity.getExpiresAt()).isEqualTo(now.plusSeconds(authorizationDto.getExpiresIn() - GRACE_PERIOD_SECONDS));
       assertThat(updatedAuthorizationEntity.getTokenType()).isEqualTo(authorizationDto.getTokenType());
     }
 


### PR DESCRIPTION
I tested mockitos mocking of static methods. A bit noisy with the `try` but works like charm.