### PR TITLE
preparation for docker swarm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,5 +27,7 @@ LABEL org.label-schema.vcs-url="https://github.com/MetalDetectorRocks/metal-dete
 LABEL org.label-schema.vcs-ref=$VCS_REF
 
 COPY $SOURCE_JAR_FILE app.jar
+COPY docker-entrypoint.sh /app
 
+ENTRYPOINT ["/app/docker-entrypoint.sh"]
 CMD ["java", "-Djava.security.egd=file:/dev/./urandom", "-Xmx256m", "-jar", "app.jar"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+file_env() {
+	local var="$1"
+	local fileVar="${var}_FILE"
+	local def="${2:-}"
+	if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
+		echo >&2 "error: both $var and $fileVar are set (but are exclusive)"
+		exit 1
+	fi
+	local val="$def"
+	if [ "${!var:-}" ]; then
+		val="${!var}"
+	elif [ "${!fileVar:-}" ]; then
+		val="$(< "${!fileVar}")"
+	fi
+
+	export "$var"="$val"
+
+	unset "$fileVar"
+}
+
+envs=(
+  DATASOURCE_USERNAME
+  DATASOURCE_PASSWORD
+  BUTLER_ACCESS_TOKEN
+  SPOTIFY_CLIENT_ID
+  SPOTIFY_CLIENT_SECRET
+  DISCOGS_ACCESS_TOKEN
+  JWT_SECRET
+  MAIL_HOST
+  MAIL_USERNAME
+  MAIL_PASSWORD
+  REMEMBER_ME_SECRET
+)
+
+for e in "${envs[@]}"; do
+  file_env "$e"
+done
+
+exec "$@"


### PR DESCRIPTION
Docker Swarm manages the secrets encrypted on the host. If a container shall use a secret, docker mounts it via a file in the container. The container must therefore be smart enough to set an ENV from the contents of a file. This is now done by the new `docker-entrypoint.sh` that is copied into the docker image. 

For example, `docker run` can be executed as follows:

```bash
docker run -e JWT_SECRET=my-secret metaldetector/metal-detector
```

We already know that.

Now, also possible is:

```bash
docker run -e JWT_SECRET_FILE=/path/to/secret metaldetector/metal-detector
```

The last variant will expose the contents of the file to the ENV `JWT_SECRET`.