### PR TITLE
Notification Config Backend

### DIFF
--- a/persistence/src/main/java/rocks/metaldetector/persistence/domain/notification/NotificationConfigEntity.java
+++ b/persistence/src/main/java/rocks/metaldetector/persistence/domain/notification/NotificationConfigEntity.java
@@ -1,0 +1,41 @@
+package rocks.metaldetector.persistence.domain.notification;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.Setter;
+import rocks.metaldetector.persistence.domain.BaseEntity;
+import rocks.metaldetector.persistence.domain.user.UserEntity;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.OneToOne;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE) // for lombok builder
+@Builder
+@EqualsAndHashCode(callSuper = true)
+@Entity(name = "notificationConfigs")
+public class NotificationConfigEntity extends BaseEntity {
+
+  @OneToOne(mappedBy = "notificationConfig")
+  private UserEntity user;
+
+  @Column(name = "frequency", columnDefinition = "integer default 4")
+  @NonNull
+  private Integer frequency = 4;
+
+  @Column(name = "notificationAtReleaseDate", columnDefinition = "boolean default false")
+  @NonNull
+  private Boolean notificationAtReleaseDate = false;
+
+  @Column(name = "notificationAtAnnouncementDate", columnDefinition = "boolean default false")
+  @NonNull
+  private Boolean notificationAtAnnouncementDate = false;
+}

--- a/persistence/src/main/java/rocks/metaldetector/persistence/domain/notification/NotificationConfigEntity.java
+++ b/persistence/src/main/java/rocks/metaldetector/persistence/domain/notification/NotificationConfigEntity.java
@@ -27,9 +27,12 @@ public class NotificationConfigEntity extends BaseEntity {
   @OneToOne(mappedBy = "notificationConfig")
   private UserEntity user;
 
-  @Column(name = "frequency", columnDefinition = "integer default 4")
+  @Column(name = "notify", columnDefinition = "boolean default false")
+  private Boolean notify = false;
+
+  @Column(name = "frequencyInWeeks", columnDefinition = "integer default 4")
   @NonNull
-  private Integer frequency = 4;
+  private Integer frequencyInWeeks = 4;
 
   @Column(name = "notificationAtReleaseDate", columnDefinition = "boolean default false")
   @NonNull

--- a/persistence/src/main/java/rocks/metaldetector/persistence/domain/user/UserEntity.java
+++ b/persistence/src/main/java/rocks/metaldetector/persistence/domain/user/UserEntity.java
@@ -10,14 +10,18 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import rocks.metaldetector.persistence.domain.BaseEntity;
+import rocks.metaldetector.persistence.domain.notification.NotificationConfigEntity;
 import rocks.metaldetector.support.infrastructure.ArtifactForFramework;
 
+import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.FetchType;
+import javax.persistence.JoinColumn;
+import javax.persistence.OneToOne;
 import javax.persistence.PrePersist;
 import java.time.LocalDateTime;
 import java.util.Collection;
@@ -68,6 +72,10 @@ public class UserEntity extends BaseEntity implements UserDetails {
   @Column(name = "last_login")
   private LocalDateTime lastLogin;
 
+  @OneToOne(cascade = CascadeType.ALL)
+  @JoinColumn(name = "notification_config", referencedColumnName = "id")
+  private NotificationConfigEntity notificationConfig;
+
   @Builder
   public UserEntity(@NonNull String username, @NonNull String email, @NonNull String password,
                     @NonNull Set<UserRole> userRoles, boolean enabled) {
@@ -76,6 +84,7 @@ public class UserEntity extends BaseEntity implements UserDetails {
     this.password = password;
     this.userRoles = userRoles;
     this.enabled = enabled;
+    this.notificationConfig = new NotificationConfigEntity();
   }
 
   public void setPublicId(String newPublicId) {
@@ -158,5 +167,9 @@ public class UserEntity extends BaseEntity implements UserDetails {
 
   public void setLastLogin(LocalDateTime lastLogin) {
     this.lastLogin = lastLogin;
+  }
+
+  public void setNotificationConfig(NotificationConfigEntity notificationConfig) {
+    this.notificationConfig = notificationConfig;
   }
 }

--- a/support/src/main/java/rocks/metaldetector/support/Endpoints.java
+++ b/support/src/main/java/rocks/metaldetector/support/Endpoints.java
@@ -63,8 +63,9 @@ public class Endpoints {
     public static final String FOLLOW                         = "/follow";
     public static final String UNFOLLOW                       = "/unfollow";
 
-    public static final String USERS      = "/rest/v1/users";
-    public static final String NOTIFY     = "/rest/v1/notify";
+    public static final String USERS                = "/rest/v1/users";
+    public static final String NOTIFY               = "/rest/v1/notify";
+    public static final String NOTIFICATION_CONFIG  = "/notification-config";
 
     public static final String TEST       = "/rest/v1/only-for-testing";
   }

--- a/webapp/src/main/java/rocks/metaldetector/service/notification/NotificationConfigDto.java
+++ b/webapp/src/main/java/rocks/metaldetector/service/notification/NotificationConfigDto.java
@@ -1,0 +1,17 @@
+package rocks.metaldetector.service.notification;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class NotificationConfigDto {
+
+  private int frequency;
+  private boolean notificationAtReleaseDate;
+  private boolean notificationAtAnnouncementDate;
+}

--- a/webapp/src/main/java/rocks/metaldetector/service/notification/NotificationConfigDto.java
+++ b/webapp/src/main/java/rocks/metaldetector/service/notification/NotificationConfigDto.java
@@ -11,7 +11,8 @@ import lombok.NoArgsConstructor;
 @Builder
 public class NotificationConfigDto {
 
-  private int frequency;
+  private boolean notify;
+  private int frequencyInWeeks;
   private boolean notificationAtReleaseDate;
   private boolean notificationAtAnnouncementDate;
 }

--- a/webapp/src/main/java/rocks/metaldetector/service/notification/NotificationConfigDtoTransformer.java
+++ b/webapp/src/main/java/rocks/metaldetector/service/notification/NotificationConfigDtoTransformer.java
@@ -8,9 +8,10 @@ public class NotificationConfigDtoTransformer {
 
   public NotificationConfigEntity transform(NotificationConfigDto notificationConfigDto) {
     return NotificationConfigEntity.builder()
+        .notify(notificationConfigDto.isNotify())
         .notificationAtReleaseDate(notificationConfigDto.isNotificationAtReleaseDate())
         .notificationAtAnnouncementDate(notificationConfigDto.isNotificationAtAnnouncementDate())
-        .frequency(notificationConfigDto.getFrequency())
+        .frequencyInWeeks(notificationConfigDto.getFrequencyInWeeks())
         .build();
   }
 }

--- a/webapp/src/main/java/rocks/metaldetector/service/notification/NotificationConfigDtoTransformer.java
+++ b/webapp/src/main/java/rocks/metaldetector/service/notification/NotificationConfigDtoTransformer.java
@@ -1,0 +1,16 @@
+package rocks.metaldetector.service.notification;
+
+import org.springframework.stereotype.Component;
+import rocks.metaldetector.persistence.domain.notification.NotificationConfigEntity;
+
+@Component
+public class NotificationConfigDtoTransformer {
+
+  public NotificationConfigEntity transform(NotificationConfigDto notificationConfigDto) {
+    return NotificationConfigEntity.builder()
+        .notificationAtReleaseDate(notificationConfigDto.isNotificationAtReleaseDate())
+        .notificationAtAnnouncementDate(notificationConfigDto.isNotificationAtAnnouncementDate())
+        .frequency(notificationConfigDto.getFrequency())
+        .build();
+  }
+}

--- a/webapp/src/main/java/rocks/metaldetector/service/user/UserDto.java
+++ b/webapp/src/main/java/rocks/metaldetector/service/user/UserDto.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import rocks.metaldetector.service.notification.NotificationConfigDto;
 
 import java.time.LocalDateTime;
 
@@ -24,5 +25,6 @@ public class UserDto {
   private LocalDateTime createdDateTime;
   private LocalDateTime lastModifiedDateTime;
   private String lastModifiedBy;
+  private NotificationConfigDto notificationConfig;
 
 }

--- a/webapp/src/main/java/rocks/metaldetector/service/user/UserService.java
+++ b/webapp/src/main/java/rocks/metaldetector/service/user/UserService.java
@@ -1,6 +1,7 @@
 package rocks.metaldetector.service.user;
 
 import org.springframework.security.core.userdetails.UserDetailsService;
+import rocks.metaldetector.service.notification.NotificationConfigDto;
 
 import java.util.List;
 import java.util.Optional;
@@ -16,6 +17,8 @@ public interface UserService extends UserDetailsService {
   Optional<UserDto> getUserByEmailOrUsername(String emailOrUsername);
 
   UserDto updateUser(String publicId, UserDto userDto);
+
+  UserDto updateCurrentUserNotificationConfig(NotificationConfigDto notificationConfig);
 
   void deleteUser(String publicId);
 

--- a/webapp/src/main/java/rocks/metaldetector/service/user/UserServiceImpl.java
+++ b/webapp/src/main/java/rocks/metaldetector/service/user/UserServiceImpl.java
@@ -12,6 +12,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.comparator.BooleanComparator;
+import rocks.metaldetector.persistence.domain.notification.NotificationConfigEntity;
 import rocks.metaldetector.persistence.domain.token.TokenEntity;
 import rocks.metaldetector.persistence.domain.token.TokenRepository;
 import rocks.metaldetector.persistence.domain.user.UserEntity;
@@ -22,6 +23,8 @@ import rocks.metaldetector.security.LoginAttemptService;
 import rocks.metaldetector.service.exceptions.IllegalUserActionException;
 import rocks.metaldetector.service.exceptions.TokenExpiredException;
 import rocks.metaldetector.service.exceptions.UserAlreadyExistsException;
+import rocks.metaldetector.service.notification.NotificationConfigDto;
+import rocks.metaldetector.service.notification.NotificationConfigDtoTransformer;
 import rocks.metaldetector.service.token.TokenService;
 import rocks.metaldetector.support.JwtsSupport;
 import rocks.metaldetector.support.exceptions.ResourceNotFoundException;
@@ -46,6 +49,7 @@ public class UserServiceImpl implements UserService {
   private final TokenRepository tokenRepository;
   private final JwtsSupport jwtsSupport;
   private final UserTransformer userTransformer;
+  private final NotificationConfigDtoTransformer notificationConfigTransformer;
   private final TokenService tokenService;
   private final CurrentUserSupplier currentUserSupplier;
   private final LoginAttemptService loginAttemptService;
@@ -112,6 +116,18 @@ public class UserServiceImpl implements UserService {
     userEntity.setEnabled(userDto.isEnabled());
 
     UserEntity updatedUserEntity = userRepository.save(userEntity);
+
+    return userTransformer.transform(updatedUserEntity);
+  }
+
+  @Override
+  @Transactional
+  public UserDto updateCurrentUserNotificationConfig(NotificationConfigDto notificationConfig) {
+    UserEntity currentUser = currentUserSupplier.get();
+    NotificationConfigEntity notificationConfigEntity = notificationConfigTransformer.transform(notificationConfig);
+    currentUser.setNotificationConfig(notificationConfigEntity);
+
+    UserEntity updatedUserEntity = userRepository.save(currentUser);
 
     return userTransformer.transform(updatedUserEntity);
   }

--- a/webapp/src/main/java/rocks/metaldetector/web/api/request/UpdateNotificationConfigRequest.java
+++ b/webapp/src/main/java/rocks/metaldetector/web/api/request/UpdateNotificationConfigRequest.java
@@ -17,5 +17,6 @@ public class UpdateNotificationConfigRequest {
   private int frequency;
   private boolean notificationAtReleaseDate;
   private boolean notificationAtAnnouncementDate;
+  private boolean notify;
 
 }

--- a/webapp/src/main/java/rocks/metaldetector/web/api/request/UpdateNotificationConfigRequest.java
+++ b/webapp/src/main/java/rocks/metaldetector/web/api/request/UpdateNotificationConfigRequest.java
@@ -1,0 +1,21 @@
+package rocks.metaldetector.web.api.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.Min;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Data
+public class UpdateNotificationConfigRequest {
+
+  @Min(0L)
+  private int frequency;
+  private boolean notificationAtReleaseDate;
+  private boolean notificationAtAnnouncementDate;
+
+}

--- a/webapp/src/main/java/rocks/metaldetector/web/controller/rest/UserRestController.java
+++ b/webapp/src/main/java/rocks/metaldetector/web/controller/rest/UserRestController.java
@@ -3,7 +3,6 @@ package rocks.metaldetector.web.controller.rest;
 import lombok.AllArgsConstructor;
 import org.modelmapper.ModelMapper;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -13,9 +12,12 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import rocks.metaldetector.service.notification.NotificationConfigDto;
 import rocks.metaldetector.service.user.UserDto;
 import rocks.metaldetector.service.user.UserService;
+import rocks.metaldetector.support.Endpoints;
 import rocks.metaldetector.web.api.request.RegisterUserRequest;
+import rocks.metaldetector.web.api.request.UpdateNotificationConfigRequest;
 import rocks.metaldetector.web.api.request.UpdateUserRequest;
 import rocks.metaldetector.web.api.response.UserResponse;
 
@@ -23,18 +25,19 @@ import javax.validation.Valid;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static rocks.metaldetector.support.Endpoints.Rest.USERS;
 
 @RestController
 @RequestMapping(USERS)
 @AllArgsConstructor
-@PreAuthorize("hasRole('ROLE_ADMINISTRATOR')")
 public class UserRestController {
 
   private final UserService userService;
   private final ModelMapper mapper;
 
-  @GetMapping(produces = {MediaType.APPLICATION_XML_VALUE, MediaType.APPLICATION_JSON_VALUE})
+  @GetMapping(produces = APPLICATION_JSON_VALUE)
+  @PreAuthorize("hasRole('ROLE_ADMINISTRATOR')")
   public ResponseEntity<List<UserResponse>> getAllUsers() {
     List<UserResponse> response = userService.getAllUsers().stream()
             .map(userDto -> mapper.map(userDto, UserResponse.class))
@@ -43,7 +46,8 @@ public class UserRestController {
     return ResponseEntity.ok(response);
   }
 
-  @GetMapping(path = "/{id}", produces = {MediaType.APPLICATION_XML_VALUE, MediaType.APPLICATION_JSON_VALUE})
+  @GetMapping(path = "/{id}", produces = APPLICATION_JSON_VALUE)
+  @PreAuthorize("hasRole('ROLE_ADMINISTRATOR')")
   public ResponseEntity<UserResponse> getUser(@PathVariable(name = "id") String publicUserId) {
     UserDto userDto = userService.getUserByPublicId(publicUserId);
     UserResponse response = mapper.map(userDto, UserResponse.class);
@@ -51,8 +55,9 @@ public class UserRestController {
     return ResponseEntity.ok(response);
   }
 
-  @PostMapping(consumes = {MediaType.APPLICATION_XML_VALUE, MediaType.APPLICATION_JSON_VALUE},
-               produces = {MediaType.APPLICATION_XML_VALUE, MediaType.APPLICATION_JSON_VALUE})
+  @PostMapping(consumes = APPLICATION_JSON_VALUE,
+               produces = APPLICATION_JSON_VALUE)
+  @PreAuthorize("hasRole('ROLE_ADMINISTRATOR')")
   public ResponseEntity<UserResponse> createUser(@Valid @RequestBody RegisterUserRequest request) {
     UserDto userDto = mapper.map(request, UserDto.class);
     UserDto createdUserDto = userService.createAdministrator(userDto);
@@ -61,11 +66,23 @@ public class UserRestController {
     return ResponseEntity.status(HttpStatus.CREATED).body(response);
   }
 
-  @PutMapping(consumes = {MediaType.APPLICATION_XML_VALUE, MediaType.APPLICATION_JSON_VALUE},
-              produces = {MediaType.APPLICATION_XML_VALUE, MediaType.APPLICATION_JSON_VALUE})
+  @PutMapping(consumes = APPLICATION_JSON_VALUE,
+              produces = APPLICATION_JSON_VALUE)
+  @PreAuthorize("hasRole('ROLE_ADMINISTRATOR')")
   public ResponseEntity<UserResponse> updateUser(@Valid @RequestBody UpdateUserRequest request) {
     UserDto userDto = mapper.map(request, UserDto.class);
     UserDto updatedUserDto = userService.updateUser(request.getPublicUserId(), userDto);
+    UserResponse response = mapper.map(updatedUserDto, UserResponse.class);
+
+    return ResponseEntity.status(HttpStatus.OK).body(response);
+  }
+
+  @PutMapping(path = Endpoints.Rest.NOTIFICATION_CONFIG,
+              consumes = APPLICATION_JSON_VALUE,
+              produces = APPLICATION_JSON_VALUE)
+  public ResponseEntity<UserResponse> updateCurrentUserNotificationConfig(@Valid @RequestBody UpdateNotificationConfigRequest request) {
+    NotificationConfigDto notificationConfigDto = mapper.map(request, NotificationConfigDto.class);
+    UserDto updatedUserDto = userService.updateCurrentUserNotificationConfig(notificationConfigDto);
     UserResponse response = mapper.map(updatedUserDto, UserResponse.class);
 
     return ResponseEntity.status(HttpStatus.OK).body(response);

--- a/webapp/src/test/java/rocks/metaldetector/service/mapper/UserTransformerTest.java
+++ b/webapp/src/test/java/rocks/metaldetector/service/mapper/UserTransformerTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import rocks.metaldetector.persistence.domain.user.UserEntity;
 import rocks.metaldetector.persistence.domain.user.UserRole;
+import rocks.metaldetector.service.notification.NotificationConfigDto;
 import rocks.metaldetector.service.user.UserDto;
 import rocks.metaldetector.service.user.UserTransformer;
 
@@ -38,6 +39,7 @@ class UserTransformerTest implements WithAssertions {
     entity.setCreatedDateTime(new Date());
     entity.setLastModifiedBy("Modifier");
     entity.setLastModifiedDateTime(new Date());
+    NotificationConfigDto expectedNotificationConfig = NotificationConfigDto.builder().frequency(4).build();
     UserDto expected = UserDto.builder()
         .publicId(entity.getPublicId())
         .username(USERNAME)
@@ -50,6 +52,7 @@ class UserTransformerTest implements WithAssertions {
         .createdDateTime(entity.getCreatedDateTime())
         .lastModifiedBy(entity.getLastModifiedBy())
         .lastModifiedDateTime(entity.getLastModifiedDateTime())
+        .notificationConfig(expectedNotificationConfig)
         .build();
 
     // when

--- a/webapp/src/test/java/rocks/metaldetector/service/mapper/UserTransformerTest.java
+++ b/webapp/src/test/java/rocks/metaldetector/service/mapper/UserTransformerTest.java
@@ -39,7 +39,7 @@ class UserTransformerTest implements WithAssertions {
     entity.setCreatedDateTime(new Date());
     entity.setLastModifiedBy("Modifier");
     entity.setLastModifiedDateTime(new Date());
-    NotificationConfigDto expectedNotificationConfig = NotificationConfigDto.builder().frequency(4).build();
+    NotificationConfigDto expectedNotificationConfig = NotificationConfigDto.builder().frequencyInWeeks(4).build();
     UserDto expected = UserDto.builder()
         .publicId(entity.getPublicId())
         .username(USERNAME)

--- a/webapp/src/test/java/rocks/metaldetector/service/notification/NotificationConfigDtoTransformerTest.java
+++ b/webapp/src/test/java/rocks/metaldetector/service/notification/NotificationConfigDtoTransformerTest.java
@@ -1,0 +1,28 @@
+package rocks.metaldetector.service.notification;
+
+import org.assertj.core.api.WithAssertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class NotificationConfigDtoTransformerTest implements WithAssertions {
+
+  private final NotificationConfigDtoTransformer underTest = new NotificationConfigDtoTransformer();
+
+  @Test
+  @DisplayName("dto is transformed to entity")
+  void test_transform() {
+    // given
+    var notificationConfigDto = NotificationConfigDto.builder().frequency(4)
+        .notificationAtAnnouncementDate(true)
+        .notificationAtReleaseDate(true)
+        .build();
+
+    // when
+    var result = underTest.transform(notificationConfigDto);
+
+    // then
+    assertThat(result.getFrequency()).isEqualTo(notificationConfigDto.getFrequency());
+    assertThat(result.getNotificationAtAnnouncementDate()).isEqualTo(notificationConfigDto.isNotificationAtAnnouncementDate());
+    assertThat(result.getNotificationAtReleaseDate()).isEqualTo(notificationConfigDto.isNotificationAtReleaseDate());
+  }
+}

--- a/webapp/src/test/java/rocks/metaldetector/service/notification/NotificationConfigDtoTransformerTest.java
+++ b/webapp/src/test/java/rocks/metaldetector/service/notification/NotificationConfigDtoTransformerTest.java
@@ -12,16 +12,18 @@ class NotificationConfigDtoTransformerTest implements WithAssertions {
   @DisplayName("dto is transformed to entity")
   void test_transform() {
     // given
-    var notificationConfigDto = NotificationConfigDto.builder().frequency(4)
+    var notificationConfigDto = NotificationConfigDto.builder().frequencyInWeeks(4)
         .notificationAtAnnouncementDate(true)
         .notificationAtReleaseDate(true)
+        .notify(true)
         .build();
 
     // when
     var result = underTest.transform(notificationConfigDto);
 
     // then
-    assertThat(result.getFrequency()).isEqualTo(notificationConfigDto.getFrequency());
+    assertThat(result.getNotify()).isEqualTo(notificationConfigDto.isNotify());
+    assertThat(result.getFrequencyInWeeks()).isEqualTo(notificationConfigDto.getFrequencyInWeeks());
     assertThat(result.getNotificationAtAnnouncementDate()).isEqualTo(notificationConfigDto.isNotificationAtAnnouncementDate());
     assertThat(result.getNotificationAtReleaseDate()).isEqualTo(notificationConfigDto.isNotificationAtReleaseDate());
   }

--- a/webapp/src/test/java/rocks/metaldetector/service/user/UserServiceImplTest.java
+++ b/webapp/src/test/java/rocks/metaldetector/service/user/UserServiceImplTest.java
@@ -701,7 +701,7 @@ class UserServiceImplTest implements WithAssertions {
     @DisplayName("updateNotificationConfig: notificationConfigTransformer is called")
     void test_notification_config_update_calls_notification_config_trafo() {
       // given
-      var notificationConfig = NotificationConfigDto.builder().frequency(10).build();
+      var notificationConfig = NotificationConfigDto.builder().frequencyInWeeks(10).build();
       UserEntity user = UserEntityFactory.createUser(USERNAME, EMAIL);
       doReturn(user).when(currentUserSupplier).get();
       doReturn(null).when(notificationTransformer).transform(any());
@@ -719,7 +719,7 @@ class UserServiceImplTest implements WithAssertions {
     void test_notification_config_update_saves_user() {
       // given
       ArgumentCaptor<UserEntity> argumentCaptor = ArgumentCaptor.forClass(UserEntity.class);
-      var notificationConfigEntity = NotificationConfigEntity.builder().frequency(10)
+      var notificationConfigEntity = NotificationConfigEntity.builder().frequencyInWeeks(10)
           .notificationAtAnnouncementDate(true)
           .notificationAtReleaseDate(true).build();
       UserEntity user = UserEntityFactory.createUser(USERNAME, EMAIL);

--- a/webapp/src/test/java/rocks/metaldetector/web/controller/rest/UserRestControllerIT.java
+++ b/webapp/src/test/java/rocks/metaldetector/web/controller/rest/UserRestControllerIT.java
@@ -8,12 +8,14 @@ import org.springframework.security.test.context.support.WithMockUser;
 import rocks.metaldetector.testutil.BaseWebMvcTestWithSecurity;
 import rocks.metaldetector.testutil.DtoFactory.RegisterUserRequestFactory;
 import rocks.metaldetector.testutil.DtoFactory.UpdateUserRequestFactory;
+import rocks.metaldetector.web.api.request.UpdateNotificationConfigRequest;
 
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static rocks.metaldetector.support.Endpoints.Rest.NOTIFICATION_CONFIG;
 import static rocks.metaldetector.support.Endpoints.Rest.USERS;
 
 @WebMvcTest(controllers = UserRestController.class)
@@ -58,6 +60,16 @@ class UserRestControllerIT extends BaseWebMvcTestWithSecurity {
              .contentType(APPLICATION_JSON))
              .andExpect(status().isOk());
     }
+
+    @Test
+    @DisplayName("Administrators can PUT on endpoint " + USERS + NOTIFICATION_CONFIG)
+    @WithMockUser(roles = "ADMINISTRATOR")
+    void admin_can_update_notification_config_via_put() throws Exception {
+      mockMvc.perform(put(USERS + NOTIFICATION_CONFIG)
+                          .content(objectMapper.writeValueAsString(new UpdateNotificationConfigRequest()))
+                          .contentType(APPLICATION_JSON))
+          .andExpect(status().isOk());
+    }
   }
 
   @Nested
@@ -98,6 +110,16 @@ class UserRestControllerIT extends BaseWebMvcTestWithSecurity {
              .content(objectMapper.writeValueAsString(UpdateUserRequestFactory.createDefault()))
              .contentType(APPLICATION_JSON))
              .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("Users can PUT on endpoint " + USERS + NOTIFICATION_CONFIG)
+    @WithMockUser(roles = "USER")
+    void admin_can_update_notification_config_via_put() throws Exception {
+      mockMvc.perform(put(USERS + NOTIFICATION_CONFIG)
+                          .content(objectMapper.writeValueAsString(new UpdateNotificationConfigRequest()))
+                          .contentType(APPLICATION_JSON))
+          .andExpect(status().isOk());
     }
   }
 }

--- a/webapp/src/test/java/rocks/metaldetector/web/controller/rest/UserRestControllerTest.java
+++ b/webapp/src/test/java/rocks/metaldetector/web/controller/rest/UserRestControllerTest.java
@@ -371,7 +371,7 @@ class UserRestControllerTest implements WithAssertions {
     @DisplayName("updateNotificationConfig: should call userService")
     void test_should_call_user_service() {
       // given
-      var notificationConfig = NotificationConfigDto.builder().frequency(1).build();
+      var notificationConfig = NotificationConfigDto.builder().frequencyInWeeks(1).build();
       doReturn(UserDtoFactory.createDefault()).when(userService).updateCurrentUserNotificationConfig(any());
       doReturn(notificationConfig).when(modelMapper).map(any(), eq(NotificationConfigDto.class));
 


### PR DESCRIPTION
Users have a default notification config which can be updated via rest endpoint. I started with the NotificationEntity having the one-to-one to the UserEntity but this way it is not that easy having a default automatically created when the user is created so I switched it to the User (making is bigger again, i know...).
Second maybe a bit weird point is that the endpoint to update the config is `/rest/v1/users/notification-config` - without the user id after `users`. So it is only possible to change one's own config currently. This way we don't have to worry some calling the endpoint with userIds other than his own. What's your opinion on this?