### PR TITLE
https forwarding temporarily disabled

### DIFF
--- a/webapp/src/main/java/rocks/metaldetector/security/SecurityConfig.java
+++ b/webapp/src/main/java/rocks/metaldetector/security/SecurityConfig.java
@@ -57,8 +57,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
   @Override
   protected void configure(HttpSecurity http) throws Exception {
     http
-      .requiresChannel().requestMatchers(request -> request.getHeader("X-Forwarded-Proto") != null).requiresSecure()
-      .and()
+//      .requiresChannel().requestMatchers(request -> request.getHeader("X-Forwarded-Proto") != null).requiresSecure()
+//      .and()
       .csrf().ignoringAntMatchers(REST_ENDPOINTS, ACTUATOR_ENDPOINTS)
       .and()
       .authorizeRequests()


### PR DESCRIPTION
To be able to test the nginx proxy setup without HTTPS first.