### PR TITLE
fix docker health check

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,4 +1,4 @@
-name: Build and deploy docker container image
+name: Build docker container image
 
 on:
   push:
@@ -57,20 +57,3 @@ jobs:
             BUILD_DATE=${{ steps.version.outputs.version }}
             VCS_REF=${{ github.ref }}
             HEALTH_CHECK_ENDPOINT=${{ secrets.HEALTH_CHECK_ENDPOINT }}
-
-      - name: Push image to Heroku Registry
-        run: |
-          docker pull metaldetector/metal-detector
-          docker login --username=_ --password=${{ secrets.HEROKU_API_KEY }} registry.heroku.com
-          docker tag metaldetector/metal-detector registry.heroku.com/${{ secrets.HEROKU_PREVIEW_APP_NAME }}/web
-          docker push registry.heroku.com/${{ secrets.HEROKU_PREVIEW_APP_NAME }}/web
-
-      - name: Login to Heroku Container Registry
-        env:
-          HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
-        run: heroku container:login
-
-      - name: Deploy docker image on Heroku
-        env:
-          HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
-        run: heroku container:release -a ${{ secrets.HEROKU_PREVIEW_APP_NAME }} web

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,15 @@ FROM openjdk:15-slim-buster
 
 ENV TZ=Europe/Berlin
 
+RUN apt-get update && apt-get install -y \
+  curl \
+  && rm -rf /var/lib/apt/lists/*
+
 RUN mkdir /app && mkdir /app/logs
 WORKDIR /app
 
-RUN useradd --no-log-init --no-create-home --shell /bin/false service_user
-RUN chown -cR service_user:service_user /app
+RUN useradd --no-log-init --no-create-home --shell /bin/false service_user \
+  && chown -cR service_user:service_user /app
 USER service_user
 
 VOLUME ["/app/logs/"]
@@ -27,7 +31,7 @@ LABEL org.label-schema.url="https://metal-detector.rocks"
 LABEL org.label-schema.vcs-url="https://github.com/MetalDetectorRocks/metal-detector-main"
 LABEL org.label-schema.vcs-ref=$VCS_REF
 
-#HEALTHCHECK --start-period=10s --interval=10s --timeout=5s --retries=3 CMD curl --fail $HEALTH_CHECK_ENDPOINT || exit 1
+HEALTHCHECK --start-period=10s --interval=10s --timeout=5s --retries=3 CMD curl --fail http://localhost:8080/$HEALTH_CHECK_ENDPOINT || exit 1
 
 COPY $SOURCE_JAR_FILE app.jar
 COPY docker-entrypoint.sh /app

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: java -Dserver.port=$PORT $JAVA_OPTS -jar webapp/target/*.jar

--- a/system.properties
+++ b/system.properties
@@ -1,0 +1,1 @@
+java.runtime.version=15

--- a/webapp/src/main/java/rocks/metaldetector/security/SecurityConfig.java
+++ b/webapp/src/main/java/rocks/metaldetector/security/SecurityConfig.java
@@ -57,8 +57,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
   @Override
   protected void configure(HttpSecurity http) throws Exception {
     http
-//      .requiresChannel().requestMatchers(request -> request.getHeader("X-Forwarded-Proto") != null).requiresSecure()
-//      .and()
+      .requiresChannel().requestMatchers(request -> request.getHeader("X-Forwarded-Proto") != null).requiresSecure()
+      .and()
       .csrf().ignoringAntMatchers(REST_ENDPOINTS, ACTUATOR_ENDPOINTS)
       .and()
       .authorizeRequests()

--- a/webapp/src/main/resources/application-preview.yml
+++ b/webapp/src/main/resources/application-preview.yml
@@ -23,7 +23,7 @@ spring:
             enable: true
 
 server:
-  port: ${PORT}
+  port: 8080
   error:
     whitelabel:
       enabled: false


### PR DESCRIPTION
We can't use the Docker healthchecks on Heroku, so we'll deploy the .jar there again. 