### PR TITLE
improve docker health check

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -56,4 +56,3 @@ jobs:
           build-args: |
             BUILD_DATE=${{ steps.version.outputs.version }}
             VCS_REF=${{ github.ref }}
-            HEALTH_CHECK_ENDPOINT=${{ secrets.HEALTH_CHECK_ENDPOINT }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,6 @@ VOLUME ["/app/logs/"]
 ARG SOURCE_JAR_FILE="webapp/target/*.jar"
 ARG BUILD_DATE
 ARG VCS_REF
-ARG HEALTH_CHECK_ENDPOINT
 
 # Labels
 LABEL org.label-schema.schema-version="1.0"
@@ -31,7 +30,7 @@ LABEL org.label-schema.url="https://metal-detector.rocks"
 LABEL org.label-schema.vcs-url="https://github.com/MetalDetectorRocks/metal-detector-main"
 LABEL org.label-schema.vcs-ref=$VCS_REF
 
-HEALTHCHECK --start-period=10s --interval=10s --timeout=5s --retries=3 CMD curl --fail http://localhost:8080/$HEALTH_CHECK_ENDPOINT || exit 1
+HEALTHCHECK --start-period=30s --interval=10s --timeout=5s --retries=3 CMD curl --fail http://localhost:8080/actuator/health || exit 1
 
 COPY $SOURCE_JAR_FILE app.jar
 COPY docker-entrypoint.sh /app

--- a/webapp/src/main/resources/application-preview.yml
+++ b/webapp/src/main/resources/application-preview.yml
@@ -34,7 +34,10 @@ server:
 management:
   endpoints:
     web:
-      base-path: ${ACTUATOR_BASE_PATH}
+      path-mapping.info: ${ACTUATOR_INFO_PATH}
+      path-mapping.metrics: ${ACTUATOR_METRICS_PATH}
+      path-mapping.prometheus: ${ACTUATOR_PROMETHEUS_PATH}
+      path-mapping.flyway: ${ACTUATOR_FLYWAY_PATH}
 
 metal-release-butler:
   host: https://metal-release-butler-preview.herokuapp.com

--- a/webapp/src/main/resources/application-prod.yml
+++ b/webapp/src/main/resources/application-prod.yml
@@ -34,7 +34,10 @@ server:
 management:
   endpoints:
     web:
-      base-path: ${ACTUATOR_BASE_PATH}
+      path-mapping.info: ${ACTUATOR_INFO_PATH}
+      path-mapping.metrics: ${ACTUATOR_METRICS_PATH}
+      path-mapping.prometheus: ${ACTUATOR_PROMETHEUS_PATH}
+      path-mapping.flyway: ${ACTUATOR_FLYWAY_PATH}
 
 metal-release-butler:
   host: http://butler-app:8080

--- a/webapp/src/main/resources/application.yml
+++ b/webapp/src/main/resources/application.yml
@@ -33,7 +33,7 @@ spring:
       config: classpath:config/cache/ehcache.xml
   mail:
     properties:
-      from: no-reply@metal-detector.rocks
+      from: notifications@metal-detector.rocks
   thymeleaf:
     enabled: true
     prefix: classpath:/templates/
@@ -64,7 +64,7 @@ management:
     web:
       base-path: /actuator
       exposure:
-        include: health, info, metrics, prometheus
+        include: health, info, metrics, prometheus, flyway
 
 discogs:
   access-token: ${DISCOGS_ACCESS_TOKEN}


### PR DESCRIPTION
The path for the healthcheck must be specified directly in the Dockerfile. A placeholder mechanism does not work here. 

Therefore, we now work without obfuscation for the `/health` endpoint. The endpoints `/info`, `/metrics`, `/prometheus` and `/flyway` will hide behind an obfuscated URL.