### PR TITLE
Spotfiy search for queries with Umlaut fixed

### DIFF
--- a/discogs/src/test/java/rocks/metaldetector/discogs/config/DiscogsRequestInterceptorTest.java
+++ b/discogs/src/test/java/rocks/metaldetector/discogs/config/DiscogsRequestInterceptorTest.java
@@ -53,7 +53,7 @@ class DiscogsRequestInterceptorTest implements WithAssertions {
   }
 
   @Test
-  @DisplayName("should set user agent with value from ButlerConfig")
+  @DisplayName("should set user agent with value from DiscogsConfig")
   void user_agent_header_is_set() throws IOException {
     // given
     var userAgent = "User Agent";
@@ -68,7 +68,7 @@ class DiscogsRequestInterceptorTest implements WithAssertions {
   }
 
   @Test
-  @DisplayName("should set authorization header with token from ButlerConfig")
+  @DisplayName("should set authorization header with token from DiscogsConfig")
   void authorization_header_is_set() throws IOException {
     // given
     var token = "discogs token";

--- a/spotify/src/main/java/rocks/metaldetector/spotify/client/SpotifyArtistSearchClientImpl.java
+++ b/spotify/src/main/java/rocks/metaldetector/spotify/client/SpotifyArtistSearchClientImpl.java
@@ -15,7 +15,6 @@ import rocks.metaldetector.spotify.api.search.SpotifyArtistsContainer;
 import rocks.metaldetector.spotify.config.SpotifyProperties;
 import rocks.metaldetector.support.exceptions.ExternalServiceException;
 
-import java.net.URLEncoder;
 import java.nio.charset.Charset;
 import java.util.Collections;
 import java.util.List;
@@ -50,7 +49,6 @@ public class SpotifyArtistSearchClientImpl implements SpotifyArtistSearchClient 
     }
 
     HttpEntity<Object> httpEntity = createQueryHttpEntity(authorizationToken);
-    String urlEncodedQuery = URLEncoder.encode(artistQueryString, Charset.defaultCharset());
     int offset = pageSize * (pageNumber - 1);
 
     ResponseEntity<SpotifyArtistSearchResultContainer> responseEntity = spotifyRestTemplate.exchange(
@@ -58,7 +56,7 @@ public class SpotifyArtistSearchClientImpl implements SpotifyArtistSearchClient 
         GET,
         httpEntity,
         SpotifyArtistSearchResultContainer.class,
-        Map.of(QUERY_PARAMETER_NAME, urlEncodedQuery,
+        Map.of(QUERY_PARAMETER_NAME, artistQueryString,
                OFFSET_PARAMETER_NAME, offset,
                LIMIT_PARAMETER_NAME, pageSize)
     );
@@ -68,6 +66,7 @@ public class SpotifyArtistSearchClientImpl implements SpotifyArtistSearchClient 
     if (shouldNotHappen) {
       throw new ExternalServiceException("Could not get search results for query '" + artistQueryString + "' (Response code: " + responseEntity.getStatusCode() + ")");
     }
+
 
     return resultContainer;
   }

--- a/spotify/src/main/java/rocks/metaldetector/spotify/config/SpotifyModuleConfig.java
+++ b/spotify/src/main/java/rocks/metaldetector/spotify/config/SpotifyModuleConfig.java
@@ -27,6 +27,7 @@ public class SpotifyModuleConfig {
     return new RestTemplateBuilder()
         .requestFactory(() -> clientHttpRequestFactory)
         .errorHandler(new CustomClientErrorHandler())
+        .interceptors(new SpotifyRequestInterceptor())
         .messageConverters(List.of(jackson2HttpMessageConverter, stringHttpMessageConverter, formHttpMessageConverter))
         .build();
   }

--- a/spotify/src/main/java/rocks/metaldetector/spotify/config/SpotifyRequestInterceptor.java
+++ b/spotify/src/main/java/rocks/metaldetector/spotify/config/SpotifyRequestInterceptor.java
@@ -1,0 +1,22 @@
+package rocks.metaldetector.spotify.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpRequest;
+import org.springframework.http.client.ClientHttpRequestExecution;
+import org.springframework.http.client.ClientHttpRequestInterceptor;
+import org.springframework.http.client.ClientHttpResponse;
+import rocks.metaldetector.support.infrastructure.WithTokenRemover;
+
+import java.io.IOException;
+
+@Slf4j
+public class SpotifyRequestInterceptor implements ClientHttpRequestInterceptor, WithTokenRemover {
+
+  @Override
+  public ClientHttpResponse intercept(HttpRequest request, byte[] body, ClientHttpRequestExecution execution) throws IOException {
+    log.info("URI: {}", request.getURI());
+    log.info("Headers: {}", removeTokenForLogging(request.getHeaders().toString()));
+
+    return execution.execute(request, body);
+  }
+}

--- a/spotify/src/test/java/rocks/metaldetector/spotify/client/SpotifyArtistSearchClientImplTest.java
+++ b/spotify/src/test/java/rocks/metaldetector/spotify/client/SpotifyArtistSearchClientImplTest.java
@@ -47,7 +47,6 @@ import static rocks.metaldetector.spotify.client.SpotifyArtistSearchClientImpl.G
 import static rocks.metaldetector.spotify.client.SpotifyArtistSearchClientImpl.ID_PARAMETER_NAME;
 import static rocks.metaldetector.spotify.client.SpotifyArtistSearchClientImpl.LIMIT_PARAMETER_NAME;
 import static rocks.metaldetector.spotify.client.SpotifyArtistSearchClientImpl.OFFSET_PARAMETER_NAME;
-import static rocks.metaldetector.spotify.client.SpotifyArtistSearchClientImpl.QUERY_PARAMETER_NAME;
 import static rocks.metaldetector.spotify.client.SpotifyArtistSearchClientImpl.SEARCH_ENDPOINT;
 import static rocks.metaldetector.spotify.client.SpotifyDtoFactory.SpotfiyArtistFactory;
 import static rocks.metaldetector.spotify.client.SpotifyDtoFactory.SpotifyArtistSearchResultContainerFactory;
@@ -179,24 +178,6 @@ class SpotifyArtistSearchClientImplTest implements WithAssertions {
 
       // then
       verify(restTemplate).exchange(any(), any(), any(), eq(SpotifyArtistSearchResultContainer.class), anyMap());
-    }
-
-    @Test
-    @DisplayName("query is url-encoded")
-    void test_encoded_query() {
-      // given
-      var query = "i'm a query";
-      var expectedQuery = "i%27m+a+query";
-      SpotifyArtistSearchResultContainer responseMock = SpotifyArtistSearchResultContainerFactory.createDefault();
-      doReturn(ResponseEntity.ok(responseMock)).when(restTemplate).exchange(any(), any(), any(), ArgumentMatchers.<Class<SpotifyArtistSearchResultContainer>>any(), anyMap());
-
-      // when
-      underTest.searchByName("token", query, 1, 10);
-
-      // then
-      verify(restTemplate).exchange(any(), any(), any(), ArgumentMatchers.<Class<SpotifyArtistSearchResultContainer>>any(), urlParameterCaptor.capture());
-      Map<String, Object> urlParameter = urlParameterCaptor.getValue();
-      assertThat(urlParameter.get(QUERY_PARAMETER_NAME)).isEqualTo(expectedQuery);
     }
 
     @ParameterizedTest(name = "for pageNumber = {0} and pageSize = {1} offset is = {2}")

--- a/spotify/src/test/java/rocks/metaldetector/spotify/config/SpotifyRequestInterceptorTest.java
+++ b/spotify/src/test/java/rocks/metaldetector/spotify/config/SpotifyRequestInterceptorTest.java
@@ -1,0 +1,35 @@
+package rocks.metaldetector.spotify.config;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpRequest;
+import org.springframework.http.client.ClientHttpRequestExecution;
+
+import java.io.IOException;
+
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class SpotifyRequestInterceptorTest {
+
+  private final SpotifyRequestInterceptor underTest = new SpotifyRequestInterceptor();
+
+  @Test
+  @DisplayName("should call 'execute' on ClientHttpRequestExecution")
+  void execute_is_called() throws IOException {
+    // given
+    var httpRequestMock = mock(HttpRequest.class);
+    var httpHeadersMock = mock(HttpHeaders.class);
+    var clientHttpRequestExecutionMock = mock(ClientHttpRequestExecution.class);
+    var bodyAsByteArray = new byte[]{};
+    doReturn(httpHeadersMock).when(httpRequestMock).getHeaders();
+
+    // when
+    underTest.intercept(httpRequestMock, bodyAsByteArray, clientHttpRequestExecutionMock);
+
+    // then
+    verify(clientHttpRequestExecutionMock).execute(httpRequestMock, bodyAsByteArray);
+  }
+}


### PR DESCRIPTION
The url-encoding is done by the rest template. If we do this too, it breaks -.-