### PR TITLE
Dependabot ignores restAssured and jakarta.xml.bind-api

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,8 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: "restAssuredVersion"
+        versions: ["4.3.x"]
+      - dependency-name: "jakarta.xml.bind-api"
+        versions: ["3.x"]


### PR DESCRIPTION
restAssured 4.3 has a bug and does not work with spring-boot 2.4 and all our dependencies use the bind-api in 2.x.x so 3 does not work here.
This should close the existing dependabot PRs and open one new for restAssured 4.2.1