### PR TITLE
Following/unfollowing now also possible on homepage

### DIFF
--- a/persistence/src/main/java/rocks/metaldetector/persistence/domain/artist/ArtistRepository.java
+++ b/persistence/src/main/java/rocks/metaldetector/persistence/domain/artist/ArtistRepository.java
@@ -18,17 +18,17 @@ public interface ArtistRepository extends JpaRepository<ArtistEntity, Long> {
 
   boolean existsByExternalIdAndSource(String externalId, ArtistSource source);
 
-  @Query(value = "select a.artist_name as artistName, a.external_id as externalId, " +
+  @Query(value = "select a.artist_name as artistName, a.external_id as externalId, a.source as source," +
                  "a.image_xs as imageXs, a.image_s as imageS, a.image_m as imageM, a.image_l as imageL " +
-                 "from artists as a left join follow_actions as fa on a.id = fa.artist_id " +
-                 "group by a.artist_name, a.external_id, a.image_xs, a.image_s, a.image_m, a.image_l " +
+                 "from follow_actions as fa left join artists as a on a.id = fa.artist_id " +
+                 "group by a.artist_name, a.external_id, a.source, a.image_xs, a.image_s, a.image_m, a.image_l " +
                  "order by count(a.id) desc " +
                  "limit :limit",
          nativeQuery = true)
   List<TopArtist> findTopArtists(@Param("limit") int limit);
 
   @Query(value = "select count(a.external_id) " +
-                 "from artists a left join follow_actions fa on a.id = fa.artist_id " +
+                 "from follow_actions fa left join artists a on a.id = fa.artist_id " +
                  "where a.external_id = :externalId",
          nativeQuery = true)
   int countArtistFollower(@Param("externalId") String externalId);

--- a/persistence/src/main/java/rocks/metaldetector/persistence/domain/artist/TopArtist.java
+++ b/persistence/src/main/java/rocks/metaldetector/persistence/domain/artist/TopArtist.java
@@ -4,4 +4,5 @@ public interface TopArtist extends MultipleSizeImages {
 
   String getExternalId();
   String getArtistName();
+  ArtistSource getSource();
 }

--- a/persistence/src/test/java/rocks/metaldetector/persistence/domain/artist/ArtistRepositoryIT.java
+++ b/persistence/src/test/java/rocks/metaldetector/persistence/domain/artist/ArtistRepositoryIT.java
@@ -165,6 +165,7 @@ class ArtistRepositoryIT extends BaseDataJpaTest implements WithAssertions, With
     assertThat(result.get(0).getImageM()).isEqualTo(artist3.getImageM());
     assertThat(result.get(0).getImageL()).isEqualTo(artist3.getImageL());
     assertThat(result.get(0).getExternalId()).isEqualTo(artist3.getExternalId());
+    assertThat(result.get(0).getSource().getDisplayName()).isEqualTo(artist3.getSource().getDisplayName());
 
     assertThat(result.get(1).getArtistName()).isEqualTo(artist2.getArtistName());
     assertThat(result.get(1).getImageXs()).isEqualTo(artist2.getImageXs());
@@ -172,6 +173,7 @@ class ArtistRepositoryIT extends BaseDataJpaTest implements WithAssertions, With
     assertThat(result.get(1).getImageM()).isEqualTo(artist2.getImageM());
     assertThat(result.get(1).getImageL()).isEqualTo(artist2.getImageL());
     assertThat(result.get(1).getExternalId()).isEqualTo(artist2.getExternalId());
+    assertThat(result.get(1).getSource().getDisplayName()).isEqualTo(artist2.getSource().getDisplayName());
   }
 
   @Test

--- a/webapp/src/main/java/rocks/metaldetector/service/artist/transformer/ArtistDtoTransformer.java
+++ b/webapp/src/main/java/rocks/metaldetector/service/artist/transformer/ArtistDtoTransformer.java
@@ -44,6 +44,7 @@ public class ArtistDtoTransformer {
     return ArtistDto.builder()
             .externalId(topArtist.getExternalId())
             .artistName(topArtist.getArtistName())
+            .source(topArtist.getSource().getDisplayName())
             .images(transformImages(topArtist))
             .build();
   }

--- a/webapp/src/main/resources/static/ts/src/bundles/homepage.ts
+++ b/webapp/src/main/resources/static/ts/src/bundles/homepage.ts
@@ -3,12 +3,25 @@ import { HomepageRenderService } from "../service/homepage-render-service";
 import { AlertService } from "../service/alert-service";
 import { LoadingIndicatorService } from "../service/loading-indicator-service";
 import { DateService } from "../service/date-service";
+import { FollowArtistService } from "../service/follow-artist-service";
+import { ArtistsRestClient } from "../clients/artists-rest-client";
+import { UrlService } from "../service/url-service";
+import { ToastService } from "../service/toast-service";
 
 const alertService = new AlertService();
 const loadingIndicatorService = new LoadingIndicatorService();
 const dateService = new DateService();
 const homepageRestClient = new HomepageRestClient();
-const homepageRenderService = new HomepageRenderService(alertService, loadingIndicatorService, dateService);
+const urlService = new UrlService();
+const toastService = new ToastService();
+const artistsRestClient = new ArtistsRestClient(urlService, toastService);
+const followArtistService = new FollowArtistService(artistsRestClient, toastService);
+const homepageRenderService = new HomepageRenderService(
+    alertService,
+    loadingIndicatorService,
+    dateService,
+    followArtistService,
+);
 
 const response = homepageRestClient.fetchHomepage();
 homepageRenderService.render(response);

--- a/webapp/src/main/resources/static/ts/src/service/homepage-render-service.ts
+++ b/webapp/src/main/resources/static/ts/src/service/homepage-render-service.ts
@@ -5,6 +5,7 @@ import { AbstractRenderService } from "./abstract-render-service";
 import { Artist } from "../model/artist.model";
 import { Release } from "../model/release.model";
 import { DateFormat, DateService } from "./date-service";
+import { FollowArtistService } from "./follow-artist-service";
 
 interface HomepageCard {
     readonly divElement: HTMLDivElement;
@@ -16,6 +17,7 @@ interface HomepageCard {
 
 export class HomepageRenderService extends AbstractRenderService<HomepageResponse> {
     private readonly dateService: DateService;
+    private readonly followArtistService: FollowArtistService;
     private readonly artistTemplateElement: HTMLTemplateElement;
     private readonly releaseTemplateElement: HTMLTemplateElement;
     private readonly MAX_CARDS_PER_ROW: number = 4;
@@ -25,11 +27,13 @@ export class HomepageRenderService extends AbstractRenderService<HomepageRespons
         alertService: AlertService,
         loadingIndicatorService: LoadingIndicatorService,
         dateService: DateService,
+        followArtistService: FollowArtistService,
     ) {
         super(alertService, loadingIndicatorService);
         this.dateService = dateService;
-        this.artistTemplateElement = document.getElementById("artist-card")! as HTMLTemplateElement;
-        this.releaseTemplateElement = document.getElementById("release-card")! as HTMLTemplateElement;
+        this.followArtistService = followArtistService;
+        this.artistTemplateElement = document.getElementById("artist-card") as HTMLTemplateElement;
+        this.releaseTemplateElement = document.getElementById("release-card") as HTMLTemplateElement;
     }
 
     protected getHostElementId(): string {
@@ -119,6 +123,9 @@ export class HomepageRenderService extends AbstractRenderService<HomepageRespons
         const artistDivElement = artistTemplateNode.firstElementChild as HTMLDivElement;
         const artistThumbElement = artistDivElement.querySelector("#artist-thumb") as HTMLImageElement;
         const artistNameElement = artistDivElement.querySelector("#artist-name") as HTMLParagraphElement;
+        const followIconElement = artistDivElement.querySelector("#follow-icon") as HTMLDivElement;
+        const followIcon = followIconElement.getElementsByTagName("img").item(0) as HTMLImageElement;
+        followIconElement.addEventListener("click", this.handleFollowIconClick.bind(this, followIcon, artist));
 
         artistThumbElement.src = artist.mediumImage;
         artistNameElement.textContent = artist.artistName;
@@ -192,5 +199,13 @@ export class HomepageRenderService extends AbstractRenderService<HomepageRespons
             const placeholderDivElement = this.renderPlaceholderCard();
             this.attachCard(placeholderDivElement, rowElement);
         }
+    }
+
+    private handleFollowIconClick(followIconElement: HTMLImageElement, artist: Artist): void {
+        this.followArtistService.handleFollowIconClick(followIconElement, {
+            externalId: artist.externalId,
+            artistName: artist.artistName,
+            source: artist.source,
+        });
     }
 }

--- a/webapp/src/main/resources/templates/frontend/home.html
+++ b/webapp/src/main/resources/templates/frontend/home.html
@@ -14,6 +14,9 @@
             <div class="col-lg-3">
                 <div class="card mb-3">
                     <img class="vertical-card-img" src="#" alt="" id="artist-thumb">
+                    <div id="follow-icon" class="top-right follow-icon-my-artists">
+                        <img src="#" th:src="@{/images/pommesgabel.svg}" alt="follow" width="32">
+                    </div>
                     <div class="card-body">
                         <p class="h5 card-title" id="artist-name"></p>
                     </div>

--- a/webapp/src/test/java/rocks/metaldetector/service/artist/transformer/ArtistDtoTransformerTest.java
+++ b/webapp/src/test/java/rocks/metaldetector/service/artist/transformer/ArtistDtoTransformerTest.java
@@ -4,6 +4,7 @@ import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import rocks.metaldetector.persistence.domain.artist.ArtistEntity;
+import rocks.metaldetector.persistence.domain.artist.ArtistSource;
 import rocks.metaldetector.persistence.domain.artist.FollowActionEntity;
 import rocks.metaldetector.persistence.domain.artist.TopArtist;
 import rocks.metaldetector.service.artist.ArtistDto;
@@ -67,6 +68,7 @@ class ArtistDtoTransformerTest implements WithAssertions {
     // given
     TopArtist topArtist = mock(TopArtist.class);
     doReturn("artist").when(topArtist).getArtistName();
+    doReturn("spotify").when(topArtist).getSource();
     doReturn("http://example.com/image-xs.jpg").when(topArtist).getImageXs();
     doReturn("http://example.com/image-s.jpg").when(topArtist).getImageS();
     doReturn("http://example.com/image-m.jpg").when(topArtist).getImageM();
@@ -83,6 +85,7 @@ class ArtistDtoTransformerTest implements WithAssertions {
     assertThat(result.getImages().get(M)).isEqualTo(topArtist.getImageM());
     assertThat(result.getImages().get(L)).isEqualTo(topArtist.getImageL());
     assertThat(result.getExternalId()).isEqualTo(topArtist.getExternalId());
+    assertThat(result.getSource()).isEqualTo(topArtist.getSource());
   }
 
   @Test

--- a/webapp/src/test/java/rocks/metaldetector/service/artist/transformer/ArtistDtoTransformerTest.java
+++ b/webapp/src/test/java/rocks/metaldetector/service/artist/transformer/ArtistDtoTransformerTest.java
@@ -4,7 +4,6 @@ import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import rocks.metaldetector.persistence.domain.artist.ArtistEntity;
-import rocks.metaldetector.persistence.domain.artist.ArtistSource;
 import rocks.metaldetector.persistence.domain.artist.FollowActionEntity;
 import rocks.metaldetector.persistence.domain.artist.TopArtist;
 import rocks.metaldetector.service.artist.ArtistDto;
@@ -68,7 +67,7 @@ class ArtistDtoTransformerTest implements WithAssertions {
     // given
     TopArtist topArtist = mock(TopArtist.class);
     doReturn("artist").when(topArtist).getArtistName();
-    doReturn("spotify").when(topArtist).getSource();
+    doReturn(SPOTIFY).when(topArtist).getSource();
     doReturn("http://example.com/image-xs.jpg").when(topArtist).getImageXs();
     doReturn("http://example.com/image-s.jpg").when(topArtist).getImageS();
     doReturn("http://example.com/image-m.jpg").when(topArtist).getImageM();
@@ -85,7 +84,7 @@ class ArtistDtoTransformerTest implements WithAssertions {
     assertThat(result.getImages().get(M)).isEqualTo(topArtist.getImageM());
     assertThat(result.getImages().get(L)).isEqualTo(topArtist.getImageL());
     assertThat(result.getExternalId()).isEqualTo(topArtist.getExternalId());
-    assertThat(result.getSource()).isEqualTo(topArtist.getSource());
+    assertThat(result.getSource()).isEqualTo(topArtist.getSource().getDisplayName());
   }
 
   @Test


### PR DESCRIPTION
Also fixed a little bug where an artist that is not followed anymore by any users was still shown in the communities favorite artists row. The join statement was wrong there. And yes, this would never be visible in production 😉