### PR TITLE
use same postgres version for local development as in production

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3.7'
 services: 
   detector-db:
     container_name: detector-db
-    image: postgres:12-alpine
+    image: postgres:13.1-alpine
     environment:
       POSTGRES_PASSWORD: secret
       POSTGRES_DB: metal-detector
@@ -20,7 +20,7 @@ services:
 
   butler-db:
     container_name: butler-db
-    image: postgres:12-alpine
+    image: postgres:13.1-alpine
     environment:
       POSTGRES_PASSWORD: secret
       POSTGRES_DB: metal-release-butler


### PR DESCRIPTION
As a result, the Postgres database must be recreated locally once. It is best to simply delete the Docker volume beforehand.