### PR TITLE
gradle cleanup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ buildscript {
 }
 
 plugins {
-  id "java"
+  id "java-library"
   id "org.siouan.frontend-jdk11"
   id "org.springframework.boot"
   id "io.spring.dependency-management"
@@ -54,6 +54,7 @@ ext {
                         "org.webjars:jquery:3.6.0"]
   dependencyGroupVersions = ["org.springframework"           : "5.3.4",
                              "org.springframework.security"  : springSecurityVersion,
+                             "org.springframework.boot"      : springBootVersion,
                              "com.fasterxml.jackson.core"    : jacksonVersion,
                              "com.fasterxml.jackson.datatype": jacksonVersion,
                              "com.fasterxml.jackson.module"  : jacksonVersion]
@@ -87,11 +88,14 @@ allprojects {
 }
 
 springBoot {
-  mainClassName = 'rocks.metaldetector.MetalDetectorApplication'
+  mainClass.set('rocks.metaldetector.MetalDetectorApplication')
+}
+
+dependencies {
+  developmentOnly "org.springframework.boot:spring-boot-devtools"
 }
 
 subprojects {
-  apply plugin: "java"
   apply plugin: "java-library"
   apply plugin: "io.spring.dependency-management"
   apply plugin: "jacoco"
@@ -104,18 +108,17 @@ subprojects {
   }
 
   dependencies {
-    implementation "org.springframework.boot:spring-boot-starter-security:$springBootVersion"
-    implementation "org.springframework.boot:spring-boot-starter-cache:$springBootVersion"
-    implementation "org.springframework.boot:spring-boot-configuration-processor:$springBootVersion"
+    implementation "org.springframework.boot:spring-boot-starter-security"
+    implementation "org.springframework.boot:spring-boot-starter-cache"
+    implementation "org.springframework.boot:spring-boot-configuration-processor"
 
     implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-xml:$jacksonVersion"
     implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonVersion"
     implementation "org.projectlombok:lombok:$lombokVersion"
 
-    runtimeOnly "org.springframework.boot:spring-boot-devtools:$springBootVersion"
     annotationProcessor "org.projectlombok:lombok:$lombokVersion"
 
-    testImplementation "org.springframework.boot:spring-boot-starter-test:$springBootVersion" exclude group: 'junit', module: 'junit'
+    testImplementation "org.springframework.boot:spring-boot-starter-test" exclude group: 'junit', module: 'junit'
     testImplementation "org.springframework.security:spring-security-test:$springSecurityVersion"
     testImplementation "org.junit.jupiter:junit-jupiter:$junitVersion"
     testImplementation "org.junit.vintage:junit-vintage-engine:$junitVersion"
@@ -141,7 +144,7 @@ subprojects {
   }
 
   wrapper {
-    gradleVersion = "6.7.1"
+    gradleVersion = "6.8.3"
     distributionType = Wrapper.DistributionType.ALL
   }
 }

--- a/butler/build.gradle
+++ b/butler/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-  implementation "org.springframework.boot:spring-boot-starter-web:$springBootVersion"
+  implementation "org.springframework.boot:spring-boot-starter-web"
 
   implementation project(":support")
 

--- a/discogs/build.gradle
+++ b/discogs/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-  implementation "org.springframework.boot:spring-boot-starter-web:$springBootVersion"
+  implementation "org.springframework.boot:spring-boot-starter-web"
 
   implementation project(":support")
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/persistence/build.gradle
+++ b/persistence/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-  api "org.springframework.boot:spring-boot-starter-data-jpa:$springBootVersion"
+  api "org.springframework.boot:spring-boot-starter-data-jpa"
 
   implementation "org.postgresql:postgresql:$postgresqlVersion"
 

--- a/spotify/build.gradle
+++ b/spotify/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-  implementation "org.springframework.boot:spring-boot-starter-web:$springBootVersion"
+  implementation "org.springframework.boot:spring-boot-starter-web"
   implementation "org.apache.commons:commons-text"
 
   implementation project(":support")

--- a/webapp/build.gradle
+++ b/webapp/build.gradle
@@ -12,11 +12,11 @@ jar {
 }
 
 dependencies {
-  implementation "org.springframework.boot:spring-boot-starter-web:$springBootVersion"
-  implementation "org.springframework.boot:spring-boot-starter-mail:$springBootVersion"
-  implementation "org.springframework.boot:spring-boot-starter-actuator:$springBootVersion"
-  implementation "org.springframework.boot:spring-boot-starter-thymeleaf:$springBootVersion"
-  implementation "org.springframework.boot:spring-boot-starter-validation:$springBootVersion"
+  implementation "org.springframework.boot:spring-boot-starter-web"
+  implementation "org.springframework.boot:spring-boot-starter-mail"
+  implementation "org.springframework.boot:spring-boot-starter-actuator"
+  implementation "org.springframework.boot:spring-boot-starter-thymeleaf"
+  implementation "org.springframework.boot:spring-boot-starter-validation"
 
   implementation "org.thymeleaf.extras:thymeleaf-extras-springsecurity5:$thymeleafExtrasVersion"
   implementation "nz.net.ultraq.thymeleaf:thymeleaf-layout-dialect:$thymeleafDialectVersion"


### PR DESCRIPTION
- dependency management is now working correctly, spring boot version does not have to be added everywhere
- dev-tools are added as developmentOnly on root level (not needed in submodules) so the jar is not packed into the final jar anymore
- deprecated method in root gradle replaced
- gradle wrapper updated