### PR TITLE
Plugin versions moved to build.gradle so dependabot recognises them

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,9 +34,9 @@ buildscript {
 
 plugins {
   id "java-library"
-  id "org.siouan.frontend-jdk11"
-  id "org.springframework.boot"
-  id "io.spring.dependency-management"
+  id "org.siouan.frontend-jdk11" version "4.0.1"
+  id "org.springframework.boot" version "2.4.3"
+  id "io.spring.dependency-management" version "1.0.10.RELEASE"
 }
 
 ext {

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,11 +1,3 @@
-pluginManagement {
-  plugins {
-    id "org.springframework.boot" version "2.4.2"
-    id "io.spring.dependency-management" version "1.0.10.RELEASE"
-    id "org.siouan.frontend-jdk11" version "4.0.1"
-  }
-}
-
 rootProject.name = "metal-detector"
 include(":butler")
 include(":discogs")


### PR DESCRIPTION
I used the older spring boot version deliberately to test is dependabot now really gets it.