### PR TITLE
Spring Boot OAuth Integration with Spotify

### DIFF
--- a/spotify/src/main/java/rocks/metaldetector/spotify/client/SpotifyArtistSearchClient.java
+++ b/spotify/src/main/java/rocks/metaldetector/spotify/client/SpotifyArtistSearchClient.java
@@ -8,10 +8,10 @@ import java.util.List;
 
 public interface SpotifyArtistSearchClient {
 
-  SpotifyArtistSearchResultContainer searchByName(String authorizationToken, String artistQueryString, int pageNumber, int pageSize);
+  SpotifyArtistSearchResultContainer searchByName(String artistQueryString, int pageNumber, int pageSize);
 
-  SpotifyArtist searchById(String authenticationToken, String artistId);
+  SpotifyArtist searchById(String artistId);
 
-  SpotifyArtistsContainer searchByIds(String authenticationToken, List<String> artistIds);
+  SpotifyArtistsContainer searchByIds(List<String> artistIds);
 
 }

--- a/spotify/src/main/java/rocks/metaldetector/spotify/client/SpotifyArtistSearchClientMock.java
+++ b/spotify/src/main/java/rocks/metaldetector/spotify/client/SpotifyArtistSearchClientMock.java
@@ -21,7 +21,7 @@ import java.util.Map;
 public class SpotifyArtistSearchClientMock implements SpotifyArtistSearchClient {
 
   @Override
-  public SpotifyArtistSearchResultContainer searchByName(String authorizationToken, String artistQueryString, int pageNumber, int pageSize) {
+  public SpotifyArtistSearchResultContainer searchByName(String artistQueryString, int pageNumber, int pageSize) {
     return SpotifyArtistSearchResultContainer.builder()
         .artists(SpotifyArtistSearchResult.builder()
                      .href("https://api.spotify.com/v1/search?query=Opeth&type=artist&offset=0&limit=20")
@@ -36,12 +36,12 @@ public class SpotifyArtistSearchClientMock implements SpotifyArtistSearchClient 
   }
 
   @Override
-  public SpotifyArtist searchById(String authenticationToken, String artistId) {
+  public SpotifyArtist searchById(String artistId) {
     return createOpeth();
   }
 
   @Override
-  public SpotifyArtistsContainer searchByIds(String authenticationToken, List<String> artistIds) {
+  public SpotifyArtistsContainer searchByIds(List<String> artistIds) {
     return SpotifyArtistsContainer.builder()
         .artists(List.of(createOpeth(), createDarkthrone()))
         .build();

--- a/spotify/src/main/java/rocks/metaldetector/spotify/client/SpotifyAuthorizationClient.java
+++ b/spotify/src/main/java/rocks/metaldetector/spotify/client/SpotifyAuthorizationClient.java
@@ -4,8 +4,6 @@ import rocks.metaldetector.spotify.api.authorization.SpotifyUserAuthorizationRes
 
 public interface SpotifyAuthorizationClient {
 
-  String getAppAuthorizationToken();
-
   SpotifyUserAuthorizationResponse getUserAuthorizationToken(String code);
 
   SpotifyUserAuthorizationResponse refreshUserAuthorizationToken(String refreshToken);

--- a/spotify/src/main/java/rocks/metaldetector/spotify/client/SpotifyAuthorizationClientMock.java
+++ b/spotify/src/main/java/rocks/metaldetector/spotify/client/SpotifyAuthorizationClientMock.java
@@ -15,11 +15,6 @@ public class SpotifyAuthorizationClientMock implements SpotifyAuthorizationClien
   static final String MOCK_TOKEN = "i'm a token";
 
   @Override
-  public String getAppAuthorizationToken() {
-    return MOCK_TOKEN;
-  }
-
-  @Override
   public SpotifyUserAuthorizationResponse getUserAuthorizationToken(String code) {
     return SpotifyUserAuthorizationResponse.builder()
         .accessToken(MOCK_TOKEN)

--- a/spotify/src/main/java/rocks/metaldetector/spotify/client/SpotifyUserLibraryClientImpl.java
+++ b/spotify/src/main/java/rocks/metaldetector/spotify/client/SpotifyUserLibraryClientImpl.java
@@ -8,7 +8,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
-import org.springframework.web.client.RestTemplate;
+import org.springframework.web.client.RestOperations;
 import rocks.metaldetector.spotify.api.imports.SpotifyFollowedArtistsPage;
 import rocks.metaldetector.spotify.api.imports.SpotifyFollowedArtistsPageContainer;
 import rocks.metaldetector.spotify.api.imports.SpotifySavedAlbumsPage;
@@ -34,7 +34,7 @@ public class SpotifyUserLibraryClientImpl implements SpotifyUserLibraryClient {
   static final String MY_ALBUMS_ENDPOINT = "/v1/me/albums?limit={" + LIMIT_PARAMETER_NAME + "}&" +
                                                "offset={" + OFFSET_PARAMETER_NAME + "}";
 
-  private final RestTemplate spotifyRestTemplate;
+  private final RestOperations spotifyRestTemplate;
   private final SpotifyProperties spotifyProperties;
 
   @Override

--- a/spotify/src/main/java/rocks/metaldetector/spotify/facade/SpotifyServiceImpl.java
+++ b/spotify/src/main/java/rocks/metaldetector/spotify/facade/SpotifyServiceImpl.java
@@ -50,15 +50,13 @@ public class SpotifyServiceImpl implements SpotifyService {
 
   @Override
   public SpotifyArtistSearchResultDto searchArtistByName(String artistQueryString, int pageNumber, int pageSize) {
-    String authorizationToken = authorizationClient.getAppAuthorizationToken();
-    SpotifyArtistSearchResultContainer searchResult = artistSearchClient.searchByName(authorizationToken, artistQueryString, pageNumber, pageSize);
+    SpotifyArtistSearchResultContainer searchResult = artistSearchClient.searchByName(artistQueryString, pageNumber, pageSize);
     return searchResultTransformer.transform(searchResult);
   }
 
   @Override
   public SpotifyArtistDto searchArtistById(String artistId) {
-    String authenticationToken = authorizationClient.getAppAuthorizationToken();
-    SpotifyArtist spotifyArtist = artistSearchClient.searchById(authenticationToken, artistId);
+    SpotifyArtist spotifyArtist = artistSearchClient.searchById(artistId);
     return artistTransformer.transform(spotifyArtist);
   }
 
@@ -68,8 +66,7 @@ public class SpotifyServiceImpl implements SpotifyService {
     int totalPages = (int) Math.ceil((double) artistIds.size() / (double) PAGE_SIZE);
     for (int i = 1; i <= totalPages; i++) {
       List<String> idsPerPage = slicingService.slice(artistIds, i, PAGE_SIZE);
-      String authenticationToken = authorizationClient.getAppAuthorizationToken();
-      SpotifyArtistsContainer spotifyArtistsContainer = artistSearchClient.searchByIds(authenticationToken, idsPerPage);
+      SpotifyArtistsContainer spotifyArtistsContainer = artistSearchClient.searchByIds(idsPerPage);
       spotifyArtists.addAll(spotifyArtistsContainer.getArtists());
     }
     return spotifyArtists.stream()

--- a/spotify/src/test/java/rocks/metaldetector/spotify/client/SpotifyArtistSearchClientImplTest.java
+++ b/spotify/src/test/java/rocks/metaldetector/spotify/client/SpotifyArtistSearchClientImplTest.java
@@ -21,7 +21,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.client.RestTemplate;
+import org.springframework.web.client.RestOperations;
 import rocks.metaldetector.spotify.api.SpotifyArtist;
 import rocks.metaldetector.spotify.api.search.SpotifyArtistSearchResultContainer;
 import rocks.metaldetector.spotify.api.search.SpotifyArtistsContainer;
@@ -40,7 +40,6 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
-import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.http.HttpMethod.GET;
 import static rocks.metaldetector.spotify.client.SpotifyArtistSearchClientImpl.GET_ARTISTS_ENDPOINT;
 import static rocks.metaldetector.spotify.client.SpotifyArtistSearchClientImpl.GET_ARTIST_ENDPOINT;
@@ -54,10 +53,8 @@ import static rocks.metaldetector.spotify.client.SpotifyDtoFactory.SpotifyArtist
 @ExtendWith(MockitoExtension.class)
 class SpotifyArtistSearchClientImplTest implements WithAssertions {
 
-  private static final String AUTHORIZATION_HEADER_PREFIX = "Bearer ";
-
   @Mock
-  private RestTemplate restTemplate;
+  private RestOperations restTemplate;
 
   @Mock
   private SpotifyProperties spotifyProperties;
@@ -93,7 +90,7 @@ class SpotifyArtistSearchClientImplTest implements WithAssertions {
       SpotifyArtistSearchResultContainer emptyResult = SpotifyArtistSearchResultContainer.builder().build();
 
       // when
-      SpotifyArtistSearchResultContainer result = underTest.searchByName("token", invalidQuery, 1, 10);
+      SpotifyArtistSearchResultContainer result = underTest.searchByName(invalidQuery, 1, 10);
 
       // then
       assertThat(result).isEqualTo(emptyResult);
@@ -110,7 +107,7 @@ class SpotifyArtistSearchClientImplTest implements WithAssertions {
       doReturn(ResponseEntity.ok(responseMock)).when(restTemplate).exchange(any(), any(), any(), ArgumentMatchers.<Class<SpotifyArtistSearchResultContainer>>any(), anyMap());
 
       // when
-      underTest.searchByName("token", "query", 1, 10);
+      underTest.searchByName("query", 1, 10);
 
       // then
       verify(restTemplate).exchange(eq(expectedUrl), any(), any(), ArgumentMatchers.<Class<SpotifyArtistSearchResultContainer>>any(), anyMap());
@@ -124,7 +121,7 @@ class SpotifyArtistSearchClientImplTest implements WithAssertions {
       doReturn(ResponseEntity.ok(responseMock)).when(restTemplate).exchange(any(), any(), any(), ArgumentMatchers.<Class<SpotifyArtistSearchResultContainer>>any(), anyMap());
 
       // when
-      underTest.searchByName("token", "query", 1, 10);
+      underTest.searchByName("query", 1, 10);
 
       // then
       verify(restTemplate).exchange(any(), eq(GET), any(), ArgumentMatchers.<Class<SpotifyArtistSearchResultContainer>>any(), anyMap());
@@ -138,7 +135,7 @@ class SpotifyArtistSearchClientImplTest implements WithAssertions {
       doReturn(ResponseEntity.ok(responseMock)).when(restTemplate).exchange(any(), any(), any(), ArgumentMatchers.<Class<SpotifyArtistSearchResultContainer>>any(), anyMap());
 
       // when
-      underTest.searchByName("token", "query", 1, 10);
+      underTest.searchByName("query", 1, 10);
 
       // then
       verify(restTemplate).exchange(any(), any(), httpEntityCaptor.capture(), ArgumentMatchers.<Class<SpotifyArtistSearchResultContainer>>any(), anyMap());
@@ -149,24 +146,6 @@ class SpotifyArtistSearchClientImplTest implements WithAssertions {
     }
 
     @Test
-    @DisplayName("token is set  with prefix in authorization header")
-    void test_correct_authorization_header() {
-      // given
-      var token = "token";
-      SpotifyArtistSearchResultContainer responseMock = SpotifyArtistSearchResultContainerFactory.createDefault();
-      doReturn(ResponseEntity.ok(responseMock)).when(restTemplate).exchange(any(), any(), any(), ArgumentMatchers.<Class<SpotifyArtistSearchResultContainer>>any(), anyMap());
-
-      // when
-      underTest.searchByName(token, "query", 1, 10);
-
-      // then
-      verify(restTemplate).exchange(any(), any(), httpEntityCaptor.capture(), ArgumentMatchers.<Class<SpotifyArtistSearchResultContainer>>any(), anyMap());
-      HttpEntity<Object> httpEntity = httpEntityCaptor.getValue();
-      HttpHeaders headers = httpEntity.getHeaders();
-      assertThat(headers.get(AUTHORIZATION)).isEqualTo(Collections.singletonList(AUTHORIZATION_HEADER_PREFIX + token));
-    }
-
-    @Test
     @DisplayName("correct response type is requested")
     void test_correct_response_type() {
       // given
@@ -174,7 +153,7 @@ class SpotifyArtistSearchClientImplTest implements WithAssertions {
       doReturn(ResponseEntity.ok(responseMock)).when(restTemplate).exchange(any(), any(), any(), ArgumentMatchers.<Class<SpotifyArtistSearchResultContainer>>any(), anyMap());
 
       // when
-      underTest.searchByName("token", "query", 1, 10);
+      underTest.searchByName("query", 1, 10);
 
       // then
       verify(restTemplate).exchange(any(), any(), any(), eq(SpotifyArtistSearchResultContainer.class), anyMap());
@@ -189,7 +168,7 @@ class SpotifyArtistSearchClientImplTest implements WithAssertions {
       doReturn(ResponseEntity.ok(responseMock)).when(restTemplate).exchange(any(), any(), any(), ArgumentMatchers.<Class<SpotifyArtistSearchResultContainer>>any(), anyMap());
 
       // when
-      underTest.searchByName("token", "query", pageNumber, pageSize);
+      underTest.searchByName("query", pageNumber, pageSize);
 
       // then
       verify(restTemplate).exchange(any(), any(), any(), ArgumentMatchers.<Class<SpotifyArtistSearchResultContainer>>any(), urlParameterCaptor.capture());
@@ -206,7 +185,7 @@ class SpotifyArtistSearchClientImplTest implements WithAssertions {
       doReturn(ResponseEntity.ok(responseMock)).when(restTemplate).exchange(any(), any(), any(), ArgumentMatchers.<Class<SpotifyArtistSearchResultContainer>>any(), anyMap());
 
       // when
-      underTest.searchByName("token", "query", 1, limit);
+      underTest.searchByName("query", 1, limit);
 
       // then
       verify(restTemplate).exchange(any(), any(), any(), ArgumentMatchers.<Class<SpotifyArtistSearchResultContainer>>any(), urlParameterCaptor.capture());
@@ -222,7 +201,7 @@ class SpotifyArtistSearchClientImplTest implements WithAssertions {
       doReturn(ResponseEntity.ok(responseMock)).when(restTemplate).exchange(any(), any(), any(), ArgumentMatchers.<Class<SpotifyArtistSearchResultContainer>>any(), anyMap());
 
       // when
-      SpotifyArtistSearchResultContainer result = underTest.searchByName("token", "query", 1, 10);
+      SpotifyArtistSearchResultContainer result = underTest.searchByName("query", 1, 10);
 
       // then
       assertThat(result).isEqualTo(responseMock);
@@ -235,7 +214,7 @@ class SpotifyArtistSearchClientImplTest implements WithAssertions {
       doReturn(ResponseEntity.ok(null)).when(restTemplate).exchange(any(), any(), any(), ArgumentMatchers.<Class<SpotifyArtistSearchResultContainer>>any(), anyMap());
 
       // when
-      Throwable throwable = catchThrowable(() -> underTest.searchByName("token", "query", 1, 10));
+      Throwable throwable = catchThrowable(() -> underTest.searchByName("query", 1, 10));
 
       // then
       assertThat(throwable).isInstanceOf(ExternalServiceException.class);
@@ -250,7 +229,7 @@ class SpotifyArtistSearchClientImplTest implements WithAssertions {
       doReturn(ResponseEntity.status(httpStatus).body(responseMock)).when(restTemplate).exchange(any(), any(), any(), ArgumentMatchers.<Class<SpotifyArtistSearchResultContainer>>any(), anyMap());
 
       // when
-      Throwable throwable = catchThrowable(() -> underTest.searchByName("token", "query", 1, 10));
+      Throwable throwable = catchThrowable(() -> underTest.searchByName("query", 1, 10));
 
       // then
       assertThat(throwable).isInstanceOf(ExternalServiceException.class);
@@ -287,7 +266,7 @@ class SpotifyArtistSearchClientImplTest implements WithAssertions {
     @DisplayName("An IllegalArgumentException is thrown when artistId is invalid.")
     void test_invalid_artist_id(String artistId) {
       // when
-      var throwable = catchThrowable(() -> underTest.searchById("token", artistId));
+      var throwable = catchThrowable(() -> underTest.searchById(artistId));
 
       // then
       assertThat(throwable).isInstanceOf(IllegalArgumentException.class);
@@ -304,7 +283,7 @@ class SpotifyArtistSearchClientImplTest implements WithAssertions {
       doReturn(ResponseEntity.ok(responseMock)).when(restTemplate).exchange(any(), any(), any(), spotifyArtistClass(), anyMap());
 
       // when
-      underTest.searchById("token", "666");
+      underTest.searchById("666");
 
       // then
       verify(restTemplate).exchange(eq(expectedSearchUrl), any(), any(), spotifyArtistClass(), anyMap());
@@ -318,7 +297,7 @@ class SpotifyArtistSearchClientImplTest implements WithAssertions {
       doReturn(ResponseEntity.ok(responseMock)).when(restTemplate).exchange(any(), any(), any(), spotifyArtistClass(), anyMap());
 
       // when
-      underTest.searchById("token", "666");
+      underTest.searchById("666");
 
       // then
       verify(restTemplate).exchange(any(), eq(GET), any(), spotifyArtistClass(), anyMap());
@@ -332,7 +311,7 @@ class SpotifyArtistSearchClientImplTest implements WithAssertions {
       doReturn(ResponseEntity.ok(responseMock)).when(restTemplate).exchange(any(), any(), any(), spotifyArtistClass(), anyMap());
 
       // when
-      underTest.searchById("token", "666");
+      underTest.searchById("666");
 
       // then
       verify(restTemplate).exchange(any(), any(), httpEntityCaptor.capture(), spotifyArtistClass(), anyMap());
@@ -343,24 +322,6 @@ class SpotifyArtistSearchClientImplTest implements WithAssertions {
     }
 
     @Test
-    @DisplayName("token is set  with prefix in authorization header")
-    void test_correct_authorization_header() {
-      // given
-      var token = "token";
-      var responseMock = SpotfiyArtistFactory.withArtistName("Slayer");
-      doReturn(ResponseEntity.ok(responseMock)).when(restTemplate).exchange(any(), any(), any(), spotifyArtistClass(), anyMap());
-
-      // when
-      underTest.searchById(token, "666");
-
-      // then
-      verify(restTemplate).exchange(any(), any(), httpEntityCaptor.capture(), ArgumentMatchers.<Class<SpotifyArtistSearchResultContainer>>any(), anyMap());
-      HttpEntity<Object> httpEntity = httpEntityCaptor.getValue();
-      HttpHeaders headers = httpEntity.getHeaders();
-      assertThat(headers.get(AUTHORIZATION)).isEqualTo(Collections.singletonList(AUTHORIZATION_HEADER_PREFIX + token));
-    }
-
-    @Test
     @DisplayName("correct response type is requested")
     void test_correct_response_type() {
       // given
@@ -368,7 +329,7 @@ class SpotifyArtistSearchClientImplTest implements WithAssertions {
       doReturn(ResponseEntity.ok(responseMock)).when(restTemplate).exchange(any(), any(), any(), spotifyArtistClass(), anyMap());
 
       // when
-      underTest.searchById("token", "666");
+      underTest.searchById("666");
 
       // then
       verify(restTemplate).exchange(any(), any(), any(), eq(SpotifyArtist.class), anyMap());
@@ -383,7 +344,7 @@ class SpotifyArtistSearchClientImplTest implements WithAssertions {
       doReturn(ResponseEntity.ok(responseMock)).when(restTemplate).exchange(any(), any(), any(), spotifyArtistClass(), anyMap());
 
       // when
-      underTest.searchById("token", artistId);
+      underTest.searchById(artistId);
 
       // then
       verify(restTemplate).exchange(any(), any(), any(), spotifyArtistClass(), urlParameterCaptor.capture());
@@ -399,7 +360,7 @@ class SpotifyArtistSearchClientImplTest implements WithAssertions {
       doReturn(ResponseEntity.ok(responseMock)).when(restTemplate).exchange(any(), any(), any(), spotifyArtistClass(), anyMap());
 
       // when
-      var result = underTest.searchById("token", "666");
+      var result = underTest.searchById("666");
 
       // then
       assertThat(result).isEqualTo(responseMock);
@@ -412,7 +373,7 @@ class SpotifyArtistSearchClientImplTest implements WithAssertions {
       doReturn(ResponseEntity.ok(null)).when(restTemplate).exchange(any(), any(), any(), spotifyArtistClass(), anyMap());
 
       // when
-      Throwable throwable = catchThrowable(() -> underTest.searchById("token", "666"));
+      Throwable throwable = catchThrowable(() -> underTest.searchById("666"));
 
       // then
       assertThat(throwable).isInstanceOf(ExternalServiceException.class);
@@ -427,7 +388,7 @@ class SpotifyArtistSearchClientImplTest implements WithAssertions {
       doReturn(ResponseEntity.status(httpStatus).body(responseMock)).when(restTemplate).exchange(any(), any(), any(), spotifyArtistClass(), anyMap());
 
       // when
-      Throwable throwable = catchThrowable(() -> underTest.searchById("token", "666"));
+      Throwable throwable = catchThrowable(() -> underTest.searchById("666"));
 
       // then
       assertThat(throwable).isInstanceOf(ExternalServiceException.class);
@@ -459,7 +420,7 @@ class SpotifyArtistSearchClientImplTest implements WithAssertions {
     @DisplayName("An IllegalArgumentException is thrown when artistIds list is invalid.")
     void test_invalid_artist_ids(List<String> artistIds) {
       // when
-      var throwable = catchThrowable(() -> underTest.searchByIds("token", artistIds));
+      var throwable = catchThrowable(() -> underTest.searchByIds(artistIds));
 
       // then
       assertThat(throwable).isInstanceOf(IllegalArgumentException.class);
@@ -478,7 +439,7 @@ class SpotifyArtistSearchClientImplTest implements WithAssertions {
       doReturn(ResponseEntity.ok(responseMock)).when(restTemplate).exchange(any(), any(), any(), spotifyArtistContainerClass(), anyMap());
 
       // when
-      underTest.searchByIds("token", List.of("666"));
+      underTest.searchByIds(List.of("666"));
 
       // then
       verify(restTemplate).exchange(eq(expectedSearchUrl), any(), any(), spotifyArtistContainerClass(), anyMap());
@@ -494,7 +455,7 @@ class SpotifyArtistSearchClientImplTest implements WithAssertions {
       doReturn(ResponseEntity.ok(responseMock)).when(restTemplate).exchange(any(), any(), any(), spotifyArtistContainerClass(), anyMap());
 
       // when
-      underTest.searchByIds("token", List.of("666"));
+      underTest.searchByIds(List.of("666"));
 
       // then
       verify(restTemplate).exchange(any(), eq(GET), any(), spotifyArtistContainerClass(), anyMap());
@@ -510,7 +471,7 @@ class SpotifyArtistSearchClientImplTest implements WithAssertions {
       doReturn(ResponseEntity.ok(responseMock)).when(restTemplate).exchange(any(), any(), any(), spotifyArtistContainerClass(), anyMap());
 
       // when
-      underTest.searchByIds("token", List.of("666"));
+      underTest.searchByIds(List.of("666"));
 
       // then
       verify(restTemplate).exchange(any(), any(), httpEntityCaptor.capture(), spotifyArtistContainerClass(), anyMap());
@@ -518,26 +479,6 @@ class SpotifyArtistSearchClientImplTest implements WithAssertions {
       HttpHeaders headers = httpEntity.getHeaders();
       assertThat(headers.getAccept()).isEqualTo(Collections.singletonList(MediaType.APPLICATION_JSON));
       assertThat(headers.getAcceptCharset()).isEqualTo(Collections.singletonList(Charset.defaultCharset()));
-    }
-
-    @Test
-    @DisplayName("token is set  with prefix in authorization header")
-    void test_correct_authorization_header() {
-      // given
-      var token = "token";
-      var responseMock = SpotifyArtistsContainer.builder()
-          .artists(List.of(SpotfiyArtistFactory.withArtistName("Slayer")))
-          .build();
-      doReturn(ResponseEntity.ok(responseMock)).when(restTemplate).exchange(any(), any(), any(), spotifyArtistContainerClass(), anyMap());
-
-      // when
-      underTest.searchByIds(token, List.of("666"));
-
-      // then
-      verify(restTemplate).exchange(any(), any(), httpEntityCaptor.capture(), ArgumentMatchers.<Class<SpotifyArtistSearchResultContainer>>any(), anyMap());
-      HttpEntity<Object> httpEntity = httpEntityCaptor.getValue();
-      HttpHeaders headers = httpEntity.getHeaders();
-      assertThat(headers.get(AUTHORIZATION)).isEqualTo(Collections.singletonList(AUTHORIZATION_HEADER_PREFIX + token));
     }
 
     @Test
@@ -550,7 +491,7 @@ class SpotifyArtistSearchClientImplTest implements WithAssertions {
       doReturn(ResponseEntity.ok(responseMock)).when(restTemplate).exchange(any(), any(), any(), spotifyArtistContainerClass(), anyMap());
 
       // when
-      underTest.searchByIds("token", List.of("666"));
+      underTest.searchByIds(List.of("666"));
 
       // then
       verify(restTemplate).exchange(any(), any(), any(), eq(SpotifyArtistsContainer.class), anyMap());
@@ -567,7 +508,7 @@ class SpotifyArtistSearchClientImplTest implements WithAssertions {
       doReturn(ResponseEntity.ok(responseMock)).when(restTemplate).exchange(any(), any(), any(), spotifyArtistContainerClass(), anyMap());
 
       // when
-      underTest.searchByIds("token", artistIds);
+      underTest.searchByIds(artistIds);
 
       // then
       verify(restTemplate).exchange(any(), any(), any(), spotifyArtistContainerClass(), urlParameterCaptor.capture());
@@ -585,7 +526,7 @@ class SpotifyArtistSearchClientImplTest implements WithAssertions {
       doReturn(ResponseEntity.ok(responseMock)).when(restTemplate).exchange(any(), any(), any(), spotifyArtistContainerClass(), anyMap());
 
       // when
-      var result = underTest.searchByIds("token", List.of("666"));
+      var result = underTest.searchByIds(List.of("666"));
 
       // then
       assertThat(result).isEqualTo(responseMock);
@@ -598,7 +539,7 @@ class SpotifyArtistSearchClientImplTest implements WithAssertions {
       doReturn(ResponseEntity.ok(null)).when(restTemplate).exchange(any(), any(), any(), spotifyArtistContainerClass(), anyMap());
 
       // when
-      Throwable throwable = catchThrowable(() -> underTest.searchByIds("token", List.of("666")));
+      Throwable throwable = catchThrowable(() -> underTest.searchByIds(List.of("666")));
 
       // then
       assertThat(throwable).isInstanceOf(ExternalServiceException.class);
@@ -615,7 +556,7 @@ class SpotifyArtistSearchClientImplTest implements WithAssertions {
       doReturn(ResponseEntity.status(httpStatus).body(responseMock)).when(restTemplate).exchange(any(), any(), any(), spotifyArtistContainerClass(), anyMap());
 
       // when
-      Throwable throwable = catchThrowable(() -> underTest.searchByIds("token", List.of("666")));
+      Throwable throwable = catchThrowable(() -> underTest.searchByIds(List.of("666")));
 
       // then
       assertThat(throwable).isInstanceOf(ExternalServiceException.class);

--- a/spotify/src/test/java/rocks/metaldetector/spotify/client/SpotifyArtistSearchClientMockTest.java
+++ b/spotify/src/test/java/rocks/metaldetector/spotify/client/SpotifyArtistSearchClientMockTest.java
@@ -17,7 +17,7 @@ class SpotifyArtistSearchClientMockTest implements WithAssertions {
   @DisplayName("searchByName: should return mock result")
   void test_searchByName() {
     // when
-    var result = underTest.searchByName("token", "query", 1, 10);
+    var result = underTest.searchByName("query", 1, 10);
 
     // then
     assertThat(result.getArtists().getItems().size()).isEqualTo(1);
@@ -27,7 +27,7 @@ class SpotifyArtistSearchClientMockTest implements WithAssertions {
   @DisplayName("searchById: should return mock result")
   void test_searchById() {
     // when
-    var result = underTest.searchById("token", "666");
+    var result = underTest.searchById("666");
 
     // then
     assertThat(result).isNotNull();
@@ -37,7 +37,7 @@ class SpotifyArtistSearchClientMockTest implements WithAssertions {
   @DisplayName("searchByIds: should return mock result")
   void test_searchByIds() {
     // when
-    var result = underTest.searchByIds("token", List.of("id"));
+    var result = underTest.searchByIds(List.of("id"));
 
     // then
     assertThat(result).isNotNull();

--- a/spotify/src/test/java/rocks/metaldetector/spotify/client/SpotifyAuthorizationClientImplTest.java
+++ b/spotify/src/test/java/rocks/metaldetector/spotify/client/SpotifyAuthorizationClientImplTest.java
@@ -22,8 +22,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.MultiValueMap;
-import org.springframework.web.client.RestTemplate;
-import rocks.metaldetector.spotify.api.authorization.SpotifyAppAuthorizationResponse;
+import org.springframework.web.client.RestOperations;
 import rocks.metaldetector.spotify.api.authorization.SpotifyUserAuthorizationResponse;
 import rocks.metaldetector.spotify.client.SpotifyDtoFactory.SpotfiyUserAuthorizationResponseFactory;
 import rocks.metaldetector.spotify.config.SpotifyProperties;
@@ -41,7 +40,6 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
-import static rocks.metaldetector.spotify.client.SpotifyAuthorizationClientImpl.APP_AUTH_REQUEST_VALUE;
 import static rocks.metaldetector.spotify.client.SpotifyAuthorizationClientImpl.AUTHORIZATION_ENDPOINT;
 import static rocks.metaldetector.spotify.client.SpotifyAuthorizationClientImpl.CODE_REQUEST_KEY;
 import static rocks.metaldetector.spotify.client.SpotifyAuthorizationClientImpl.GRANT_TYPE_KEY;
@@ -49,7 +47,6 @@ import static rocks.metaldetector.spotify.client.SpotifyAuthorizationClientImpl.
 import static rocks.metaldetector.spotify.client.SpotifyAuthorizationClientImpl.REFRESH_TOKEN_KEY;
 import static rocks.metaldetector.spotify.client.SpotifyAuthorizationClientImpl.USER_AUTH_REQUEST_VALUE;
 import static rocks.metaldetector.spotify.client.SpotifyAuthorizationClientImpl.USER_REFRESH_AUTH_REQUEST_VALUE;
-import static rocks.metaldetector.spotify.client.SpotifyDtoFactory.SpotifyAppAuthenticationResponseFactory;
 
 @ExtendWith(MockitoExtension.class)
 class SpotifyAuthorizationClientImplTest implements WithAssertions {
@@ -57,7 +54,7 @@ class SpotifyAuthorizationClientImplTest implements WithAssertions {
   private static final String AUTHORIZATION_HEADER_PREFIX = "Basic ";
 
   @Mock
-  private RestTemplate restTemplate;
+  private RestOperations restTemplate;
 
   @Mock
   private SpotifyProperties spotifyProperties;
@@ -75,148 +72,6 @@ class SpotifyAuthorizationClientImplTest implements WithAssertions {
   @AfterEach
   void tearDown() {
     reset(restTemplate, spotifyProperties);
-  }
-
-  @Nested
-  @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-  @DisplayName("Tests for app authorization")
-  class AppAuthorizationTest {
-
-    @Test
-    @DisplayName("a POST call is made on spotify authentication endpoint")
-    void test_correct_url_is_called() {
-      // given
-      var baseUrl = "baseUrl";
-      doReturn(baseUrl).when(spotifyProperties).getAuthenticationBaseUrl();
-      var expectedUrl = baseUrl + AUTHORIZATION_ENDPOINT;
-      SpotifyAppAuthorizationResponse responseMock = SpotifyAppAuthenticationResponseFactory.createDefault();
-      doReturn(ResponseEntity.ok(responseMock)).when(restTemplate).postForEntity(anyString(), any(), any());
-
-      // when
-      underTest.getAppAuthorizationToken();
-
-      // then
-      verify(restTemplate).postForEntity(eq(expectedUrl), any(), any());
-    }
-
-    @Test
-    @DisplayName("correct request body is set")
-    void test_correct_request_body() {
-      // given
-      SpotifyAppAuthorizationResponse responseMock = SpotifyAppAuthenticationResponseFactory.createDefault();
-      doReturn(ResponseEntity.ok(responseMock)).when(restTemplate).postForEntity(anyString(), any(), any());
-
-      // when
-      underTest.getAppAuthorizationToken();
-
-      // then
-      verify(restTemplate).postForEntity(anyString(), argumentCaptor.capture(), any());
-      HttpEntity<MultiValueMap<String, String>> httpEntity = argumentCaptor.getValue();
-      assertThat(httpEntity.getBody()).isNotNull();
-      assertThat(httpEntity.getBody().size()).isEqualTo(1);
-      assertThat(httpEntity.getBody().get(GRANT_TYPE_KEY)).isEqualTo(List.of(APP_AUTH_REQUEST_VALUE));
-    }
-
-    @Test
-    @DisplayName("correct standard headers are set")
-    void test_correct_standard_headers() {
-      // given
-      SpotifyAppAuthorizationResponse responseMock = SpotifyAppAuthenticationResponseFactory.createDefault();
-      doReturn(ResponseEntity.ok(responseMock)).when(restTemplate).postForEntity(anyString(), any(), any());
-
-      // when
-      underTest.getAppAuthorizationToken();
-
-      // then
-      verify(restTemplate).postForEntity(anyString(), argumentCaptor.capture(), any());
-      HttpEntity<MultiValueMap<String, String>> httpEntity = argumentCaptor.getValue();
-      HttpHeaders headers = httpEntity.getHeaders();
-      assertThat(headers.getContentType()).isEqualTo(MediaType.APPLICATION_FORM_URLENCODED);
-      assertThat(headers.getAccept()).isEqualTo(Collections.singletonList(MediaType.APPLICATION_JSON));
-      assertThat(headers.getAcceptCharset()).isEqualTo(Collections.singletonList(Charset.defaultCharset()));
-    }
-
-    @Test
-    @DisplayName("correct authorization header is set")
-    void test_correct_authorization_header() {
-      // given
-      var clientId = "clientId";
-      doReturn(clientId).when(spotifyProperties).getClientId();
-      var clientSecret = "clientSecret";
-      doReturn(clientSecret).when(spotifyProperties).getClientSecret();
-      var expectedAuthorizationHeader = AUTHORIZATION_HEADER_PREFIX + Base64.encodeBase64String((clientId + ":" + clientSecret).getBytes());
-      SpotifyAppAuthorizationResponse responseMock = SpotifyAppAuthenticationResponseFactory.createDefault();
-      doReturn(ResponseEntity.ok(responseMock)).when(restTemplate).postForEntity(anyString(), any(), any());
-
-      // when
-      underTest.getAppAuthorizationToken();
-
-      // then
-      verify(restTemplate).postForEntity(anyString(), argumentCaptor.capture(), any());
-      HttpEntity<MultiValueMap<String, String>> httpEntity = argumentCaptor.getValue();
-      HttpHeaders headers = httpEntity.getHeaders();
-      assertThat(headers.get(AUTHORIZATION)).isEqualTo(List.of(expectedAuthorizationHeader));
-    }
-
-    @Test
-    @DisplayName("correct response type is requested")
-    void test_correct_response_type() {
-      // given
-      SpotifyAppAuthorizationResponse responseMock = SpotifyAppAuthenticationResponseFactory.createDefault();
-      doReturn(ResponseEntity.ok(responseMock)).when(restTemplate).postForEntity(anyString(), any(), any());
-
-      // when
-      underTest.getAppAuthorizationToken();
-
-      // then
-      verify(restTemplate).postForEntity(anyString(), any(), eq(SpotifyAppAuthorizationResponse.class));
-    }
-
-    @Test
-    @DisplayName("accessToken is returned")
-    void test_return_value() {
-      // given
-      SpotifyAppAuthorizationResponse responseMock = SpotifyAppAuthenticationResponseFactory.createDefault();
-      doReturn(ResponseEntity.ok(responseMock)).when(restTemplate).postForEntity(anyString(), any(), any());
-
-      // when
-      String result = underTest.getAppAuthorizationToken();
-
-      // then
-      assertThat(result).isEqualTo(responseMock.getAccessToken());
-    }
-
-    @Test
-    @DisplayName("if the response is null, an ExternalServiceException is thrown")
-    void test_exception_if_response_is_null() {
-      // given
-      doReturn(ResponseEntity.ok(null)).when(restTemplate).postForEntity(anyString(), any(), any());
-
-      // when
-      Throwable throwable = catchThrowable(() -> underTest.getAppAuthorizationToken());
-
-      // then
-      assertThat(throwable).isInstanceOf(ExternalServiceException.class);
-    }
-
-    @ParameterizedTest(name = "if the status is {0}, an ExternalServiceException is thrown")
-    @MethodSource("httpStatusCodeProvider")
-    @DisplayName("if the status code is not OK, an ExternalServiceException is thrown")
-    void test_exception_if_status_is_not_ok(HttpStatus httpStatus) {
-      // given
-      SpotifyAppAuthorizationResponse responseMock = SpotifyAppAuthenticationResponseFactory.createDefault();
-      doReturn(ResponseEntity.status(httpStatus).body(responseMock)).when(restTemplate).postForEntity(anyString(), any(), any());
-
-      // when
-      Throwable throwable = catchThrowable(() -> underTest.getAppAuthorizationToken());
-
-      // then
-      assertThat(throwable).isInstanceOf(ExternalServiceException.class);
-    }
-
-    private Stream<Arguments> httpStatusCodeProvider() {
-      return Stream.of(HttpStatus.values()).filter(status -> !status.is2xxSuccessful()).map(Arguments::of);
-    }
   }
 
   @Nested

--- a/spotify/src/test/java/rocks/metaldetector/spotify/client/SpotifyAuthorizationClientMockTest.java
+++ b/spotify/src/test/java/rocks/metaldetector/spotify/client/SpotifyAuthorizationClientMockTest.java
@@ -4,21 +4,9 @@ import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import static rocks.metaldetector.spotify.client.SpotifyAuthorizationClientMock.MOCK_TOKEN;
-
 class SpotifyAuthorizationClientMockTest implements WithAssertions {
 
-  private SpotifyAuthorizationClientMock underTest = new SpotifyAuthorizationClientMock();
-
-  @Test
-  @DisplayName("getAppAuthenticationToken: should return mock token string")
-  void test_get_app_token() {
-    // when
-    var result = underTest.getAppAuthorizationToken();
-
-    // then
-    assertThat(result).isEqualTo(MOCK_TOKEN);
-  }
+  private final SpotifyAuthorizationClientMock underTest = new SpotifyAuthorizationClientMock();
 
   @Test
   @DisplayName("getUserAuthenticationToken: should return mock response")

--- a/spotify/src/test/java/rocks/metaldetector/spotify/client/SpotifyUserLibraryClientImplTest.java
+++ b/spotify/src/test/java/rocks/metaldetector/spotify/client/SpotifyUserLibraryClientImplTest.java
@@ -21,7 +21,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.client.RestTemplate;
+import org.springframework.web.client.RestOperations;
 import rocks.metaldetector.spotify.api.imports.SpotifyFollowedArtistsPage;
 import rocks.metaldetector.spotify.api.imports.SpotifyFollowedArtistsPageContainer;
 import rocks.metaldetector.spotify.api.imports.SpotifySavedAlbumsPage;
@@ -54,7 +54,7 @@ class SpotifyUserLibraryClientImplTest implements WithAssertions {
   private static final String AUTHORIZATION_HEADER_PREFIX = "Bearer ";
 
   @Mock
-  private RestTemplate restTemplate;
+  private RestOperations restTemplate;
 
   @Mock
   private SpotifyProperties spotifyProperties;

--- a/spotify/src/test/java/rocks/metaldetector/spotify/facade/SpotifyServiceImplTest.java
+++ b/spotify/src/test/java/rocks/metaldetector/spotify/facade/SpotifyServiceImplTest.java
@@ -92,30 +92,6 @@ class SpotifyServiceImplTest implements WithAssertions {
   class SearchByNameTest {
 
     @Test
-    @DisplayName("Should call authentication client")
-    void test_authentication_client_called() {
-      // when
-      underTest.searchArtistByName("query", 1, 10);
-
-      // then
-      verify(authenticationClient).getAppAuthorizationToken();
-    }
-
-    @Test
-    @DisplayName("Should call search client with token")
-    void test_search_client_token() {
-      // given
-      var token = "token";
-      doReturn(token).when(authenticationClient).getAppAuthorizationToken();
-
-      // when
-      underTest.searchArtistByName("query", 1, 10);
-
-      // then
-      verify(searchClient).searchByName(eq(token), any(), anyInt(), anyInt());
-    }
-
-    @Test
     @DisplayName("searchClient is called with query")
     void test_search_client_query() {
       // given
@@ -125,7 +101,7 @@ class SpotifyServiceImplTest implements WithAssertions {
       underTest.searchArtistByName(query, 1, 10);
 
       // then
-      verify(searchClient).searchByName(any(), eq(query), anyInt(), anyInt());
+      verify(searchClient).searchByName(eq(query), anyInt(), anyInt());
     }
 
     @Test
@@ -138,7 +114,7 @@ class SpotifyServiceImplTest implements WithAssertions {
       underTest.searchArtistByName("query", pageNumber, 10);
 
       // then
-      verify(searchClient).searchByName(any(), any(), eq(pageNumber), anyInt());
+      verify(searchClient).searchByName(any(), eq(pageNumber), anyInt());
     }
 
     @Test
@@ -151,7 +127,7 @@ class SpotifyServiceImplTest implements WithAssertions {
       underTest.searchArtistByName("query", 1, pageSize);
 
       // then
-      verify(searchClient).searchByName(any(), any(), anyInt(), eq(pageSize));
+      verify(searchClient).searchByName(any(), anyInt(), eq(pageSize));
     }
 
     @Test
@@ -159,7 +135,7 @@ class SpotifyServiceImplTest implements WithAssertions {
     void test_call_response_transformer() {
       // given
       SpotifyArtistSearchResultContainer resultContainer = SpotifyArtistSearchResultContainerFactory.createDefault();
-      doReturn(resultContainer).when(searchClient).searchByName(any(), any(), anyInt(), anyInt());
+      doReturn(resultContainer).when(searchClient).searchByName(any(), anyInt(), anyInt());
 
       // when
       underTest.searchArtistByName("query", 1, 10);
@@ -188,30 +164,6 @@ class SpotifyServiceImplTest implements WithAssertions {
   class SearchByIdTest {
 
     @Test
-    @DisplayName("Should call authentication client")
-    void test_authentication_client_called() {
-      // when
-      underTest.searchArtistById("666");
-
-      // then
-      verify(authenticationClient).getAppAuthorizationToken();
-    }
-
-    @Test
-    @DisplayName("Should call search client with token")
-    void test_search_client_token() {
-      // given
-      var token = "token";
-      doReturn(token).when(authenticationClient).getAppAuthorizationToken();
-
-      // when
-      underTest.searchArtistById("666");
-
-      // then
-      verify(searchClient).searchById(eq(token), anyString());
-    }
-
-    @Test
     @DisplayName("Should pass provided artist id to search client")
     void should_pass_arguments() {
       // given
@@ -221,7 +173,7 @@ class SpotifyServiceImplTest implements WithAssertions {
       underTest.searchArtistById(artistId);
 
       // then
-      verify(searchClient).searchById(any(), eq(artistId));
+      verify(searchClient).searchById(eq(artistId));
     }
 
     @Test
@@ -229,7 +181,7 @@ class SpotifyServiceImplTest implements WithAssertions {
     void should_transform_search_results() {
       // given
       var artist = SpotfiyArtistFactory.withArtistName("Slayer");
-      doReturn(artist).when(searchClient).searchById(any(), any());
+      doReturn(artist).when(searchClient).searchById(any());
 
       // when
       underTest.searchArtistById("666");
@@ -244,7 +196,7 @@ class SpotifyServiceImplTest implements WithAssertions {
       // given
       var artist = SpotfiyArtistFactory.withArtistName("Slayer");
       var transformedSearchResult = SpotifyArtistDtoFactory.withArtistName("Slayer");
-      doReturn(artist).when(searchClient).searchById(any(), any());
+      doReturn(artist).when(searchClient).searchById(any());
       doReturn(transformedSearchResult).when(artistTransformer).transform(any());
 
       // when
@@ -264,7 +216,7 @@ class SpotifyServiceImplTest implements WithAssertions {
     void test_slicing_service_is_called() {
       // given
       var artists = IntStream.rangeClosed(1, 101).mapToObj(String::valueOf).collect(Collectors.toList());
-      doReturn(SpotifyArtistsContainer.builder().artists(Collections.emptyList()).build()).when(searchClient).searchByIds(any(), any());
+      doReturn(SpotifyArtistsContainer.builder().artists(Collections.emptyList()).build()).when(searchClient).searchByIds(any());
 
       // when
       underTest.searchArtistsByIds(artists);
@@ -276,47 +228,18 @@ class SpotifyServiceImplTest implements WithAssertions {
     }
 
     @Test
-    @DisplayName("authentication client is called for every page")
-    void test_authentication_client_called() {
-      // given
-      var artists = IntStream.rangeClosed(1, 101).mapToObj(String::valueOf).collect(Collectors.toList());
-      doReturn(SpotifyArtistsContainer.builder().artists(Collections.emptyList()).build()).when(searchClient).searchByIds(any(), any());
-
-      // when
-      underTest.searchArtistsByIds(artists);
-
-      // then
-      verify(authenticationClient, times(3)).getAppAuthorizationToken();
-    }
-
-    @Test
-    @DisplayName("Should call search client with token")
-    void test_search_client_token() {
-      // given
-      var token = "token";
-      doReturn(token).when(authenticationClient).getAppAuthorizationToken();
-      doReturn(SpotifyArtistsContainer.builder().artists(Collections.emptyList()).build()).when(searchClient).searchByIds(any(), any());
-
-      // when
-      underTest.searchArtistsByIds(List.of("666"));
-
-      // then
-      verify(searchClient).searchByIds(eq(token), any());
-    }
-
-    @Test
     @DisplayName("Should pass every page of provided artist ids to search client")
     void should_pass_arguments() {
       // given
       var artists = IntStream.rangeClosed(1, 101).mapToObj(String::valueOf).collect(Collectors.toList());
-      doReturn(SpotifyArtistsContainer.builder().artists(Collections.emptyList()).build()).when(searchClient).searchByIds(any(), any());
+      doReturn(SpotifyArtistsContainer.builder().artists(Collections.emptyList()).build()).when(searchClient).searchByIds(any());
       doReturn(artists).when(slicingService).slice(any(), anyInt(), anyInt());
 
       // when
       underTest.searchArtistsByIds(artists);
 
       // then
-      verify(searchClient, times(3)).searchByIds(any(), eq(artists));
+      verify(searchClient, times(3)).searchByIds(eq(artists));
     }
 
     @Test
@@ -325,7 +248,7 @@ class SpotifyServiceImplTest implements WithAssertions {
       // given
       var artists = SpotifyArtistsContainer.builder().artists(List.of(SpotfiyArtistFactory.withArtistName("Slayer"),
                                                                       SpotfiyArtistFactory.withArtistName("Darkthrone"))).build();
-      doReturn(artists).when(searchClient).searchByIds(any(), any());
+      doReturn(artists).when(searchClient).searchByIds(any());
 
       // when
       underTest.searchArtistsByIds(List.of("666"));
@@ -341,7 +264,7 @@ class SpotifyServiceImplTest implements WithAssertions {
       // given
       var artists = SpotifyArtistsContainer.builder().artists(List.of(SpotfiyArtistFactory.withArtistName("Slayer"))).build();
       var transformedSearchResult = SpotifyArtistDtoFactory.withArtistName("Slayer");
-      doReturn(artists).when(searchClient).searchByIds(any(), any());
+      doReturn(artists).when(searchClient).searchByIds(any());
       doReturn(transformedSearchResult).when(artistTransformer).transform(any());
 
       // when

--- a/support/build.gradle.kts
+++ b/support/build.gradle.kts
@@ -1,6 +1,7 @@
 dependencies {
   implementation("org.apache.commons:commons-text")
   implementation("org.apache.httpcomponents:httpclient:${rootProject.extra["httpClientVersion"]}")
+  api("org.springframework.security:spring-security-oauth2-client:${rootProject.extra["springSecurityVersion"]}")
   api("io.jsonwebtoken:jjwt:${rootProject.extra["jsonwebtokenVersion"]}")
 }
 

--- a/support/src/main/java/rocks/metaldetector/support/oauth/OAuth2ClientInterceptor.java
+++ b/support/src/main/java/rocks/metaldetector/support/oauth/OAuth2ClientInterceptor.java
@@ -1,0 +1,42 @@
+package rocks.metaldetector.support.oauth;
+
+import org.springframework.http.HttpRequest;
+import org.springframework.http.client.ClientHttpRequestExecution;
+import org.springframework.http.client.ClientHttpRequestInterceptor;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.oauth2.client.OAuth2AuthorizeRequest;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager;
+
+import java.io.IOException;
+
+import static org.springframework.security.core.authority.AuthorityUtils.createAuthorityList;
+
+public class OAuth2ClientInterceptor implements ClientHttpRequestInterceptor {
+
+  private static final AnonymousAuthenticationToken PRINCIPAL = new AnonymousAuthenticationToken("key", "anonymous", createAuthorityList("ROLE_ANONYMOUS"));
+
+  private final OAuth2AuthorizedClientManager manager;
+  private final String registrationId;
+
+  public OAuth2ClientInterceptor(OAuth2AuthorizedClientManager manager, String registrationId) {
+    this.manager = manager;
+    this.registrationId = registrationId;
+  }
+
+  @Override
+  public ClientHttpResponse intercept(HttpRequest request, byte[] body, ClientHttpRequestExecution execution) throws IOException {
+    OAuth2AuthorizeRequest authorizedRequest = OAuth2AuthorizeRequest
+        .withClientRegistrationId(registrationId)
+        .principal(PRINCIPAL)
+        .build();
+    OAuth2AuthorizedClient authorizedClient = manager.authorize(authorizedRequest);
+    if (authorizedClient == null || authorizedClient.getAccessToken() == null ||
+        authorizedClient.getAccessToken().getTokenValue() == null || authorizedClient.getAccessToken().getTokenValue().isEmpty()) {
+      throw new IllegalArgumentException("No access token for client '" + registrationId + "'");
+    }
+    request.getHeaders().setBearerAuth(authorizedClient.getAccessToken().getTokenValue());
+    return execution.execute(request, body);
+  }
+}

--- a/support/src/main/java/rocks/metaldetector/support/oauth/OAuth2ClientManagerConfig.java
+++ b/support/src/main/java/rocks/metaldetector/support/oauth/OAuth2ClientManagerConfig.java
@@ -1,0 +1,25 @@
+package rocks.metaldetector.support.oauth;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.oauth2.client.AuthorizedClientServiceOAuth2AuthorizedClientManager;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientProvider;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientProviderBuilder;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+
+@Configuration
+public class OAuth2ClientManagerConfig {
+
+  @Bean
+  public OAuth2AuthorizedClientManager authorizedClientManager(OAuth2AuthorizedClientService oAuth2AuthorizedClientService,
+                                                               ClientRegistrationRepository clients) {
+    OAuth2AuthorizedClientProvider authorizedClientProvider = OAuth2AuthorizedClientProviderBuilder.builder()
+        .clientCredentials()
+        .build();
+    var manager = new AuthorizedClientServiceOAuth2AuthorizedClientManager(clients, oAuth2AuthorizedClientService);
+    manager.setAuthorizedClientProvider(authorizedClientProvider);
+    return manager;
+  }
+}

--- a/webapp/src/main/resources/application.yml
+++ b/webapp/src/main/resources/application.yml
@@ -50,6 +50,13 @@ spring:
           google:
             client-id: ${GOOGLE_CLIENT_ID}
             client-secret: ${GOOGLE_CLIENT_SECRET}
+          spotify:
+            client-id: ${SPOTIFY_CLIENT_ID}
+            client-secret: ${SPOTIFY_CLIENT_SECRET}
+            authorization-grant-type: client_credentials
+        provider:
+          spotify:
+            tokenUri: https://accounts.spotify.com/api/token
 
 security:
   token-issuer: ${JWT_ISSUER}

--- a/webapp/src/main/resources/config/cache/ehcache.xml
+++ b/webapp/src/main/resources/config/cache/ehcache.xml
@@ -28,16 +28,4 @@
             <heap unit="MB">10</heap>
         </resources>
     </cache>
-
-    <cache alias="spotifyAppAuthorizationToken">
-        <value-type>java.lang.String</value-type>
-
-        <expiry>
-            <ttl unit="minutes">59</ttl>
-        </expiry>
-
-        <resources>
-            <heap unit="MB">1</heap>
-        </resources>
-    </cache>
 </config>


### PR DESCRIPTION
Having a bit more experience with OAuth in Spring Boot now, I refactored parts of the Spotify Authentication stuff. The normal Artist-Search uses the client_credentials-OAuth-Flow. This one is pretty straight forward and can be easily taken care of by spring boot.
I introduced an OAuth-Interceptor that uses the spring boot integration and is executed with every search request. Here is the one downside and reason this is currently a draft: the token is not cached anymore at the moment. I'm still thinking about a nice solution here.
I guess the User-Authorization with Spotify can also be done by spring boot and we can get rid of the `SpotifyAuthorizationClient` completely, but first I want the search to be nice.