### PR TITLE
Refactored fetching most expected releases and added row to fronted

### DIFF
--- a/webapp/src/main/java/rocks/metaldetector/web/api/request/TopReleasesRequest.java
+++ b/webapp/src/main/java/rocks/metaldetector/web/api/request/TopReleasesRequest.java
@@ -5,6 +5,7 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
+import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 
 @Data
@@ -14,6 +15,7 @@ import javax.validation.constraints.Min;
 public class TopReleasesRequest extends ReleasesRequest {
 
   @Min(1L)
+  @Max(50L)
   private int maxReleases;
 
   @Min(1L)

--- a/webapp/src/main/resources/static/ts/src/model/homepage-response.model.ts
+++ b/webapp/src/main/resources/static/ts/src/model/homepage-response.model.ts
@@ -4,6 +4,7 @@ import { Release } from "./release.model";
 export interface HomepageResponse {
     readonly upcomingReleases: Release[];
     readonly recentReleases: Release[];
+    readonly mostExpectedReleases: Release[];
     readonly recentlyFollowedArtists: Artist[];
     readonly favoriteCommunityArtists: Artist[];
 }

--- a/webapp/src/main/resources/static/ts/src/service/homepage-render-service.ts
+++ b/webapp/src/main/resources/static/ts/src/service/homepage-render-service.ts
@@ -53,6 +53,7 @@ export class HomepageRenderService extends AbstractRenderService<HomepageRespons
 
         this.renderRecentlyFollowedArtistsRow(response);
         this.renderFavoriteCommunityArtistsRow(response);
+        this.renderMostExpectedReleasesRow(response);
     }
 
     private renderUpcomingReleasesRow(response: HomepageResponse) {
@@ -116,6 +117,13 @@ export class HomepageRenderService extends AbstractRenderService<HomepageRespons
                 this.attachCard(artistDivElement, recentlyFollowedRowElement);
             });
         }
+    }
+
+    private renderMostExpectedReleasesRow(response: HomepageResponse) {
+        this.insertHeadingElement("The community's most expected releases");
+        const mostExpectedReleasesRowElement = this.insertRowElement();
+        this.renderReleaseCards(response.mostExpectedReleases, mostExpectedReleasesRowElement);
+        this.insertPlaceholder(response.mostExpectedReleases.length, mostExpectedReleasesRowElement);
     }
 
     private renderArtistCard(artist: Artist): HTMLDivElement {


### PR DESCRIPTION
The endpoint for fetching the top releases now also uses the paginated endpoint, therefore I also added the max-constraint to the request.