### PR TITLE
Fix duplicates in notifications, reissue notification configuration

### DIFF
--- a/persistence/src/main/java/rocks/metaldetector/persistence/domain/notification/NotificationConfigEntity.java
+++ b/persistence/src/main/java/rocks/metaldetector/persistence/domain/notification/NotificationConfigEntity.java
@@ -54,6 +54,11 @@ public class NotificationConfigEntity extends BaseEntity {
   @Builder.Default
   private Boolean notificationAtAnnouncementDate = false;
 
+  @Column(name = "notify_reissues", nullable = false, columnDefinition = "boolean default false")
+  @Setter
+  @Builder.Default
+  private Boolean notifyReissues = false;
+
   @Column(name = "last_notification_date")
   @Setter
   private LocalDate lastNotificationDate;

--- a/webapp/src/main/java/rocks/metaldetector/service/notification/config/NotificationConfigDto.java
+++ b/webapp/src/main/java/rocks/metaldetector/service/notification/config/NotificationConfigDto.java
@@ -15,5 +15,6 @@ public class NotificationConfigDto {
   private int frequencyInWeeks;
   private boolean notificationAtReleaseDate;
   private boolean notificationAtAnnouncementDate;
+  private boolean notifyReissues;
   private String channel;
 }

--- a/webapp/src/main/java/rocks/metaldetector/service/notification/config/NotificationConfigServiceImpl.java
+++ b/webapp/src/main/java/rocks/metaldetector/service/notification/config/NotificationConfigServiceImpl.java
@@ -49,6 +49,7 @@ public class NotificationConfigServiceImpl implements NotificationConfigService 
     notificationConfig.setNotificationAtAnnouncementDate(notificationConfigDto.isNotificationAtAnnouncementDate());
     notificationConfig.setNotificationAtReleaseDate(notificationConfigDto.isNotificationAtReleaseDate());
     notificationConfig.setNotify(notificationConfigDto.isNotify());
+    notificationConfig.setNotifyReissues(notificationConfigDto.isNotifyReissues());
 
     notificationConfigRepository.save(notificationConfig);
   }

--- a/webapp/src/main/java/rocks/metaldetector/service/notification/config/NotificationConfigTransformer.java
+++ b/webapp/src/main/java/rocks/metaldetector/service/notification/config/NotificationConfigTransformer.java
@@ -12,6 +12,7 @@ public class NotificationConfigTransformer {
         .notificationAtReleaseDate(notificationConfig.getNotificationAtReleaseDate())
         .notificationAtAnnouncementDate(notificationConfig.getNotificationAtAnnouncementDate())
         .frequencyInWeeks(notificationConfig.getFrequencyInWeeks())
+        .notifyReissues(notificationConfig.getNotifyReissues())
         .channel(notificationConfig.getChannel().name())
         .build();
   }

--- a/webapp/src/main/java/rocks/metaldetector/service/notification/messaging/NotificationReleaseCollector.java
+++ b/webapp/src/main/java/rocks/metaldetector/service/notification/messaging/NotificationReleaseCollector.java
@@ -21,6 +21,8 @@ import java.util.stream.Collectors;
 @AllArgsConstructor
 public class NotificationReleaseCollector {
 
+  private static final String RELEASE_STATE_OK = "OK";
+
   private final ReleaseService releaseService;
   private final FollowArtistService followArtistService;
 
@@ -32,8 +34,10 @@ public class NotificationReleaseCollector {
 
     if (!followedArtistNames.isEmpty()) {
       var now = LocalDate.now();
-      upcomingReleases = releaseService.findAllReleases(followedArtistNames, new TimeRange(now, now.plusWeeks(frequency)));
-      recentReleases = releaseService.findAllReleases(followedArtistNames, new TimeRange(now.minusWeeks(frequency), now.minusDays(1)));
+      upcomingReleases = releaseService.findAllReleases(followedArtistNames, new TimeRange(now, now.plusWeeks(frequency)))
+          .stream().filter(release -> release.getState().equals(RELEASE_STATE_OK)).collect(Collectors.toList());
+      recentReleases = releaseService.findAllReleases(followedArtistNames, new TimeRange(now.minusWeeks(frequency), now.minusDays(1)))
+          .stream().filter(release -> release.getState().equals(RELEASE_STATE_OK)).collect(Collectors.toList());
     }
     return new ReleaseContainer(upcomingReleases, recentReleases);
   }
@@ -43,7 +47,8 @@ public class NotificationReleaseCollector {
 
     if (!followedArtistNames.isEmpty()) {
       var now = LocalDate.now();
-      return releaseService.findAllReleases(followedArtistNames, new TimeRange(now, now));
+      return releaseService.findAllReleases(followedArtistNames, new TimeRange(now, now))
+          .stream().filter(release -> release.getState().equals(RELEASE_STATE_OK)).collect(Collectors.toList());
     }
     return Collections.emptyList();
   }
@@ -54,7 +59,8 @@ public class NotificationReleaseCollector {
     if (!followedArtistNames.isEmpty()) {
       var now = LocalDate.now();
       return releaseService.findAllReleases(followedArtistNames, new TimeRange(now, null)).stream()
-          .filter(release -> release.getAnnouncementDate().equals(now))
+          .filter(release -> release.getAnnouncementDate().equals(now) &&
+                             release.getState().equals(RELEASE_STATE_OK))
           .collect(Collectors.toList());
     }
     return Collections.emptyList();

--- a/webapp/src/main/java/rocks/metaldetector/service/notification/messaging/NotificationReleaseCollector.java
+++ b/webapp/src/main/java/rocks/metaldetector/service/notification/messaging/NotificationReleaseCollector.java
@@ -26,7 +26,7 @@ public class NotificationReleaseCollector {
   private final ReleaseService releaseService;
   private final FollowArtistService followArtistService;
 
-  public NotificationReleaseCollector.ReleaseContainer fetchReleasesForUserAndFrequency(AbstractUserEntity user, int frequency) {
+  public NotificationReleaseCollector.ReleaseContainer fetchReleasesForUserAndFrequency(AbstractUserEntity user, int frequency, boolean notifyReissues) {
     List<String> followedArtistNames = getFollowedArtistNames(user);
 
     List<ReleaseDto> upcomingReleases = new ArrayList<>();
@@ -34,33 +34,40 @@ public class NotificationReleaseCollector {
 
     if (!followedArtistNames.isEmpty()) {
       var now = LocalDate.now();
-      upcomingReleases = releaseService.findAllReleases(followedArtistNames, new TimeRange(now, now.plusWeeks(frequency)))
-          .stream().filter(release -> release.getState().equals(RELEASE_STATE_OK)).collect(Collectors.toList());
-      recentReleases = releaseService.findAllReleases(followedArtistNames, new TimeRange(now.minusWeeks(frequency), now.minusDays(1)))
-          .stream().filter(release -> release.getState().equals(RELEASE_STATE_OK)).collect(Collectors.toList());
+      upcomingReleases = releaseService.findAllReleases(followedArtistNames, new TimeRange(now, now.plusWeeks(frequency))).stream()
+          .filter(release -> release.getState().equals(RELEASE_STATE_OK))
+          .filter(release -> !release.isReissue() || notifyReissues)
+          .collect(Collectors.toList());
+      recentReleases = releaseService.findAllReleases(followedArtistNames, new TimeRange(now.minusWeeks(frequency), now.minusDays(1))).stream()
+          .filter(release -> release.getState().equals(RELEASE_STATE_OK))
+          .filter(release -> !release.isReissue() || notifyReissues)
+          .collect(Collectors.toList());
     }
     return new ReleaseContainer(upcomingReleases, recentReleases);
   }
 
-  public List<ReleaseDto> fetchTodaysReleaseForUser(AbstractUserEntity user) {
+  public List<ReleaseDto> fetchTodaysReleaseForUser(AbstractUserEntity user, boolean notifyReissues) {
     List<String> followedArtistNames = getFollowedArtistNames(user);
 
     if (!followedArtistNames.isEmpty()) {
       var now = LocalDate.now();
-      return releaseService.findAllReleases(followedArtistNames, new TimeRange(now, now))
-          .stream().filter(release -> release.getState().equals(RELEASE_STATE_OK)).collect(Collectors.toList());
+      return releaseService.findAllReleases(followedArtistNames, new TimeRange(now, now)).stream()
+          .filter(release -> release.getState().equals(RELEASE_STATE_OK))
+          .filter(release -> !release.isReissue() || notifyReissues)
+          .collect(Collectors.toList());
     }
     return Collections.emptyList();
   }
 
-  public List<ReleaseDto> fetchTodaysAnnouncementsForUser(AbstractUserEntity user) {
+  public List<ReleaseDto> fetchTodaysAnnouncementsForUser(AbstractUserEntity user, boolean notifyReissues) {
     List<String> followedArtistNames = getFollowedArtistNames(user);
 
     if (!followedArtistNames.isEmpty()) {
       var now = LocalDate.now();
       return releaseService.findAllReleases(followedArtistNames, new TimeRange(now, null)).stream()
-          .filter(release -> release.getAnnouncementDate().equals(now) &&
-                             release.getState().equals(RELEASE_STATE_OK))
+          .filter(release -> release.getAnnouncementDate().equals(now))
+          .filter(release -> release.getState().equals(RELEASE_STATE_OK))
+          .filter(release -> !release.isReissue() || notifyReissues)
           .collect(Collectors.toList());
     }
     return Collections.emptyList();

--- a/webapp/src/main/java/rocks/metaldetector/service/notification/messaging/NotificationScheduler.java
+++ b/webapp/src/main/java/rocks/metaldetector/service/notification/messaging/NotificationScheduler.java
@@ -47,7 +47,7 @@ public class NotificationScheduler {
   }
 
   private void frequencyNotification(NotificationConfigEntity notificationConfig, LocalDate now) {
-    NotificationReleaseCollector.ReleaseContainer releaseContainer = notificationReleaseCollector.fetchReleasesForUserAndFrequency(notificationConfig.getUser(), notificationConfig.getFrequencyInWeeks());
+    NotificationReleaseCollector.ReleaseContainer releaseContainer = notificationReleaseCollector.fetchReleasesForUserAndFrequency(notificationConfig.getUser(), notificationConfig.getFrequencyInWeeks(), notificationConfig.getNotifyReissues());
 
     if (!(releaseContainer.getUpcomingReleases().isEmpty() && releaseContainer.getRecentReleases().isEmpty())) {
       NotificationSender notificationSender = notificationSenderSupplier.apply(notificationConfig.getChannel());
@@ -59,7 +59,7 @@ public class NotificationScheduler {
   }
 
   private void releaseDateNotification(NotificationConfigEntity notificationConfig) {
-    List<ReleaseDto> todaysReleases = notificationReleaseCollector.fetchTodaysReleaseForUser(notificationConfig.getUser());
+    List<ReleaseDto> todaysReleases = notificationReleaseCollector.fetchTodaysReleaseForUser(notificationConfig.getUser(), notificationConfig.getNotifyReissues());
 
     if (!todaysReleases.isEmpty()) {
       NotificationSender notificationSender = notificationSenderSupplier.apply(notificationConfig.getChannel());
@@ -68,7 +68,7 @@ public class NotificationScheduler {
   }
 
   private void announcementDateNotification(NotificationConfigEntity notificationConfig) {
-    List<ReleaseDto> todaysAnnouncements = notificationReleaseCollector.fetchTodaysAnnouncementsForUser(notificationConfig.getUser());
+    List<ReleaseDto> todaysAnnouncements = notificationReleaseCollector.fetchTodaysAnnouncementsForUser(notificationConfig.getUser(), notificationConfig.getNotifyReissues());
 
     if (!todaysAnnouncements.isEmpty()) {
       NotificationSender notificationSender = notificationSenderSupplier.apply(notificationConfig.getChannel());

--- a/webapp/src/main/java/rocks/metaldetector/web/api/request/UpdateNotificationConfigRequest.java
+++ b/webapp/src/main/java/rocks/metaldetector/web/api/request/UpdateNotificationConfigRequest.java
@@ -17,6 +17,7 @@ public class UpdateNotificationConfigRequest {
   private boolean notify;
   private boolean notificationAtReleaseDate;
   private boolean notificationAtAnnouncementDate;
+  private boolean notifyReissues;
 
   @Min(0)
   private int frequencyInWeeks;

--- a/webapp/src/main/java/rocks/metaldetector/web/api/response/EmailConfig.java
+++ b/webapp/src/main/java/rocks/metaldetector/web/api/response/EmailConfig.java
@@ -15,4 +15,5 @@ public class EmailConfig {
   private int frequencyInWeeks;
   private boolean notificationAtReleaseDate;
   private boolean notificationAtAnnouncementDate;
+  private boolean notifyReissues;
 }

--- a/webapp/src/main/java/rocks/metaldetector/web/api/response/TelegramConfig.java
+++ b/webapp/src/main/java/rocks/metaldetector/web/api/response/TelegramConfig.java
@@ -15,6 +15,7 @@ public class TelegramConfig {
   private int frequencyInWeeks;
   private boolean notificationAtReleaseDate;
   private boolean notificationAtAnnouncementDate;
+  private boolean notifyReissues;
   private Integer registrationId;
   private boolean notificationsActivated;
 }

--- a/webapp/src/main/java/rocks/metaldetector/web/transformer/NotificationConfigResponseTransformer.java
+++ b/webapp/src/main/java/rocks/metaldetector/web/transformer/NotificationConfigResponseTransformer.java
@@ -30,6 +30,7 @@ public class NotificationConfigResponseTransformer {
         .notificationAtAnnouncementDate(request.isNotificationAtAnnouncementDate())
         .notificationAtReleaseDate(request.isNotificationAtReleaseDate())
         .notify(request.isNotify())
+        .notifyReissues(request.isNotifyReissues())
         .build();
   }
 
@@ -44,6 +45,7 @@ public class NotificationConfigResponseTransformer {
       emailConfig.setFrequencyInWeeks(notificationConfig.getFrequencyInWeeks());
       emailConfig.setNotificationAtReleaseDate(notificationConfig.isNotificationAtReleaseDate());
       emailConfig.setNotificationAtAnnouncementDate(notificationConfig.isNotificationAtAnnouncementDate());
+      emailConfig.setNotifyReissues(notificationConfig.isNotifyReissues());
     }
     return emailConfig;
   }
@@ -59,6 +61,7 @@ public class NotificationConfigResponseTransformer {
       telegramConfig.setFrequencyInWeeks(notificationConfig.getFrequencyInWeeks());
       telegramConfig.setNotificationAtReleaseDate(notificationConfig.isNotificationAtReleaseDate());
       telegramConfig.setNotificationAtAnnouncementDate(notificationConfig.isNotificationAtAnnouncementDate());
+      telegramConfig.setNotifyReissues(notificationConfig.isNotifyReissues());
       telegramConfig.setRegistrationId(telegramConfigDto.getRegistrationId());
       telegramConfig.setNotificationsActivated(telegramConfigDto.getChatId() != null);
     }

--- a/webapp/src/main/resources/db/migration/v10_0__notify_reissues.sql
+++ b/webapp/src/main/resources/db/migration/v10_0__notify_reissues.sql
@@ -1,0 +1,4 @@
+-- Creation Date: 2021-08-29
+-- Description: make reissue notifications configurable
+
+alter table notification_configs add column notify_reissues boolean default false not null;

--- a/webapp/src/main/resources/static/ts/src/model/notification-settings.model.ts
+++ b/webapp/src/main/resources/static/ts/src/model/notification-settings.model.ts
@@ -7,6 +7,7 @@ export interface DefaultNotificationConfig {
     readonly frequencyInWeeks: number;
     readonly notificationAtReleaseDate: boolean;
     readonly notificationAtAnnouncementDate: boolean;
+    readonly notifyReissues: boolean;
 }
 export interface TelegramNotificationConfig extends DefaultNotificationConfig {
     readonly notificationsActivated: boolean;

--- a/webapp/src/main/resources/static/ts/src/service/notifications/abstract-notification-settings-render-service.ts
+++ b/webapp/src/main/resources/static/ts/src/service/notifications/abstract-notification-settings-render-service.ts
@@ -19,6 +19,7 @@ export abstract class AbstractNotificationSettingsRenderService<
     private fourWeeklyFrequencyRb!: HTMLInputElement;
     private releaseDateNotificationToggle!: HTMLInputElement;
     private announcementDateNotificationToggle!: HTMLInputElement;
+    private notifyReissuesToggle!: HTMLInputElement;
 
     protected constructor(
         notificationSettingsRestClient: NotificationSettingsRestClient,
@@ -49,6 +50,7 @@ export abstract class AbstractNotificationSettingsRenderService<
         this.fourWeeklyFrequencyRb = getHtmlInputElement("4-weekly-rb");
         this.releaseDateNotificationToggle = getHtmlInputElement("release-date-notification-toggle");
         this.announcementDateNotificationToggle = getHtmlInputElement("announcement-date-notification-toggle");
+        this.notifyReissuesToggle = getHtmlInputElement("reissue-notification-toggle");
     }
 
     protected addEventListener(): void {
@@ -57,6 +59,7 @@ export abstract class AbstractNotificationSettingsRenderService<
         this.fourWeeklyFrequencyRb.addEventListener("change", this.onAnyValueChange.bind(this));
         this.releaseDateNotificationToggle.addEventListener("change", this.onAnyValueChange.bind(this));
         this.announcementDateNotificationToggle.addEventListener("change", this.onAnyValueChange.bind(this));
+        this.notifyReissuesToggle.addEventListener("change", this.onAnyValueChange.bind(this));
     }
 
     protected onRendering(notificationSettings: NotificationSettings): void {
@@ -68,6 +71,7 @@ export abstract class AbstractNotificationSettingsRenderService<
         }
         this.releaseDateNotificationToggle.checked = config.notificationAtReleaseDate;
         this.announcementDateNotificationToggle.checked = config.notificationAtAnnouncementDate;
+        this.notifyReissuesToggle.checked = config.notifyReissues;
     }
 
     private onAnyValueChange(): void {
@@ -81,6 +85,7 @@ export abstract class AbstractNotificationSettingsRenderService<
                 frequencyInWeeks: this.evaluateFrequency(),
                 notificationAtReleaseDate: this.releaseDateNotificationToggle.checked,
                 notificationAtAnnouncementDate: this.announcementDateNotificationToggle.checked,
+                notifyReissues: this.notifyReissuesToggle.checked,
                 channel: this.getChannel(),
             })
             .catch(() => {

--- a/webapp/src/main/resources/templates/frontend/notification-settings.html
+++ b/webapp/src/main/resources/templates/frontend/notification-settings.html
@@ -46,8 +46,8 @@
                                         <label class="form-check-label" for="email-4-weekly-rb">4-weekly</label>
                                     </div>
                                 </div>
-                                <div>
-                                    <label class="fw-bolder mb-2" id="extra-notifications-label">Extra notifications</label><br />
+                                <div class="mb-4">
+                                    <label class="fw-bolder mb-2">Extra notifications</label><br />
                                     <div class="form-check form-switch mb-2">
                                         <input type="checkbox" class="form-check-input" id="email-release-date-notification-toggle">
                                         <label class="form-check-label" for="email-release-date-notification-toggle">Notification on release date</label>
@@ -55,6 +55,13 @@
                                     <div class="form-check form-switch">
                                         <input type="checkbox" class="form-check-input" id="email-announcement-date-notification-toggle">
                                         <label class="form-check-label" for="email-announcement-date-notification-toggle">Notification on announcement date</label>
+                                    </div>
+                                </div>
+                                <div class="mb-4">
+                                    <label class="fw-bolder mb-2">Reissue notifications</label><br />
+                                    <div class="form-check form-switch mb-2">
+                                        <input type="checkbox" class="form-check-input" id="email-reissue-notification-toggle">
+                                        <label class="form-check-label" for="email-reissue-notification-toggle">Notifications for reissues or re-releases</label>
                                     </div>
                                 </div>
                             </fieldset>
@@ -110,6 +117,13 @@
                                             <div class="form-check form-switch">
                                                 <input type="checkbox" class="form-check-input" id="telegram-announcement-date-notification-toggle">
                                                 <label class="form-check-label" for="telegram-announcement-date-notification-toggle">Notification on announcement date</label>
+                                            </div>
+                                        </div>
+                                        <div class="mb-4">
+                                            <label class="fw-bolder mb-2">Reissue notifications</label><br />
+                                            <div class="form-check form-switch mb-2">
+                                                <input type="checkbox" class="form-check-input" id="telegram-reissue-notification-toggle">
+                                                <label class="form-check-label" for="telegram-reissue-notification-toggle">Notifications for reissues or re-releases</label>
                                             </div>
                                         </div>
                                     </fieldset>

--- a/webapp/src/test/java/rocks/metaldetector/service/notification/config/NotificationConfigServiceImplTest.java
+++ b/webapp/src/test/java/rocks/metaldetector/service/notification/config/NotificationConfigServiceImplTest.java
@@ -193,6 +193,7 @@ class NotificationConfigServiceImplTest implements WithAssertions {
           .frequencyInWeeks(4)
           .notify(true)
           .channel("EMAIL")
+          .notifyReissues(true)
           .build();
       doReturn(userEntity).when(currentUserSupplier).get();
       doReturn(Optional.of(notificationConfig)).when(notificationConfigRepository).findByUserAndChannel(any(), any());

--- a/webapp/src/test/java/rocks/metaldetector/service/notification/config/NotificationConfigTransformerTest.java
+++ b/webapp/src/test/java/rocks/metaldetector/service/notification/config/NotificationConfigTransformerTest.java
@@ -21,6 +21,7 @@ class NotificationConfigTransformerTest implements WithAssertions {
         .notificationAtReleaseDate(true)
         .notify(true)
         .channel(EMAIL)
+        .notifyReissues(true)
         .build();
 
     // when
@@ -31,6 +32,7 @@ class NotificationConfigTransformerTest implements WithAssertions {
     assertThat(result.getFrequencyInWeeks()).isEqualTo(notificationConfigEntity.getFrequencyInWeeks());
     assertThat(result.isNotificationAtAnnouncementDate()).isEqualTo(notificationConfigEntity.getNotificationAtAnnouncementDate());
     assertThat(result.isNotificationAtReleaseDate()).isEqualTo(notificationConfigEntity.getNotificationAtReleaseDate());
+    assertThat(result.isNotifyReissues()).isEqualTo(notificationConfigEntity.getNotifyReissues());
     assertThat(result.getChannel()).isEqualTo(EMAIL.name());
   }
 }

--- a/webapp/src/test/java/rocks/metaldetector/service/notification/messaging/NotificationReleaseCollectorTest.java
+++ b/webapp/src/test/java/rocks/metaldetector/service/notification/messaging/NotificationReleaseCollectorTest.java
@@ -63,7 +63,7 @@ class NotificationReleaseCollectorTest implements WithAssertions {
     @DisplayName("followArtistService is called")
     void test_follow_artist_service_called() {
       // when
-      underTest.fetchReleasesForUserAndFrequency(USER, 666);
+      underTest.fetchReleasesForUserAndFrequency(USER, 666, false);
 
       // then
       verify(followArtistService).getFollowedArtistsOfUser(USER);
@@ -84,7 +84,7 @@ class NotificationReleaseCollectorTest implements WithAssertions {
       doReturn(List.of(ReleaseDtoFactory.createDefault())).when(releaseService).findAllReleases(anyList(), any());
 
       // when
-      underTest.fetchReleasesForUserAndFrequency(USER, frequency);
+      underTest.fetchReleasesForUserAndFrequency(USER, frequency, false);
 
       // then
       verify(releaseService, times(2)).findAllReleases(eq(List.of(followedArtist.getArtistName())), argumentCaptor.capture());
@@ -102,7 +102,7 @@ class NotificationReleaseCollectorTest implements WithAssertions {
       doReturn(Collections.emptyList()).when(followArtistService).getFollowedArtistsOfUser(any());
 
       // when
-      underTest.fetchReleasesForUserAndFrequency(USER, 666);
+      underTest.fetchReleasesForUserAndFrequency(USER, 666, false);
 
       // then
       verifyNoInteractions(releaseService);
@@ -118,7 +118,7 @@ class NotificationReleaseCollectorTest implements WithAssertions {
       doReturn(releases).when(releaseService).findAllReleases(anyList(), any());
 
       // when
-      var result = underTest.fetchReleasesForUserAndFrequency(USER, 666);
+      var result = underTest.fetchReleasesForUserAndFrequency(USER, 666, false);
 
       // then
       assertThat(result).isEqualTo(expectedReleaseContainer);
@@ -136,7 +136,45 @@ class NotificationReleaseCollectorTest implements WithAssertions {
       doReturn(releases).when(releaseService).findAllReleases(anyList(), any());
 
       // when
-      var result = underTest.fetchReleasesForUserAndFrequency(USER, 666);
+      var result = underTest.fetchReleasesForUserAndFrequency(USER, 666, false);
+
+      // then
+      assertThat(result.getRecentReleases()).containsExactly(defaultRelease);
+      assertThat(result.getUpcomingReleases()).containsExactly(defaultRelease);
+    }
+
+    @Test
+    @DisplayName("reissues are returned if configured")
+    void test_reissues_returned() {
+      // given
+      var defaultRelease = ReleaseDtoFactory.createDefault();
+      var reissue = ReleaseDtoFactory.createDefault();
+      reissue.setReissue(true);
+      var releases = List.of(defaultRelease, reissue);
+      doReturn(List.of(ArtistDtoFactory.createDefault())).when(followArtistService).getFollowedArtistsOfUser(any());
+      doReturn(releases).when(releaseService).findAllReleases(anyList(), any());
+
+      // when
+      var result = underTest.fetchReleasesForUserAndFrequency(USER, 666, true);
+
+      // then
+      assertThat(result.getRecentReleases()).containsAll(releases);
+      assertThat(result.getUpcomingReleases()).containsAll(releases);
+    }
+
+    @Test
+    @DisplayName("reissues are not returned if configured")
+    void test_reissues_not_returned() {
+      // given
+      var defaultRelease = ReleaseDtoFactory.createDefault();
+      var reissue = ReleaseDtoFactory.createDefault();
+      reissue.setReissue(true);
+      var releases = List.of(defaultRelease, reissue);
+      doReturn(List.of(ArtistDtoFactory.createDefault())).when(followArtistService).getFollowedArtistsOfUser(any());
+      doReturn(releases).when(releaseService).findAllReleases(anyList(), any());
+
+      // when
+      var result = underTest.fetchReleasesForUserAndFrequency(USER, 666, false);
 
       // then
       assertThat(result.getRecentReleases()).containsExactly(defaultRelease);
@@ -152,7 +190,7 @@ class NotificationReleaseCollectorTest implements WithAssertions {
     @DisplayName("followArtistService is called")
     void test_follow_artist_service_called() {
       // when
-      underTest.fetchTodaysReleaseForUser(USER);
+      underTest.fetchTodaysReleaseForUser(USER, false);
 
       // then
       verify(followArtistService).getFollowedArtistsOfUser(USER);
@@ -170,7 +208,7 @@ class NotificationReleaseCollectorTest implements WithAssertions {
       doReturn(List.of(ReleaseDtoFactory.createDefault())).when(releaseService).findAllReleases(anyList(), any());
 
       // when
-      underTest.fetchTodaysReleaseForUser(USER);
+      underTest.fetchTodaysReleaseForUser(USER, false);
 
       // then
       verify(releaseService).findAllReleases(eq(List.of(followedArtist.getArtistName())), argumentCaptor.capture());
@@ -186,7 +224,7 @@ class NotificationReleaseCollectorTest implements WithAssertions {
       doReturn(Collections.emptyList()).when(followArtistService).getFollowedArtistsOfUser(any());
 
       // when
-      underTest.fetchTodaysReleaseForUser(USER);
+      underTest.fetchTodaysReleaseForUser(USER, false);
 
       // then
       verifyNoInteractions(releaseService);
@@ -201,7 +239,7 @@ class NotificationReleaseCollectorTest implements WithAssertions {
       doReturn(releases).when(releaseService).findAllReleases(anyList(), any());
 
       // when
-      var result = underTest.fetchTodaysReleaseForUser(USER);
+      var result = underTest.fetchTodaysReleaseForUser(USER, false);
 
       // then
       assertThat(result).isEqualTo(releases);
@@ -219,7 +257,43 @@ class NotificationReleaseCollectorTest implements WithAssertions {
       doReturn(releases).when(releaseService).findAllReleases(anyList(), any());
 
       // when
-      var result = underTest.fetchTodaysReleaseForUser(USER);
+      var result = underTest.fetchTodaysReleaseForUser(USER, false);
+
+      // then
+      assertThat(result).containsExactly(defaultRelease);
+    }
+
+    @Test
+    @DisplayName("reissues are returned if configured")
+    void test_reissues_returned() {
+      // given
+      var defaultRelease = ReleaseDtoFactory.createDefault();
+      var reissue = ReleaseDtoFactory.createDefault();
+      reissue.setReissue(true);
+      var releases = List.of(defaultRelease, reissue);
+      doReturn(List.of(ArtistDtoFactory.createDefault())).when(followArtistService).getFollowedArtistsOfUser(any());
+      doReturn(releases).when(releaseService).findAllReleases(anyList(), any());
+
+      // when
+      var result = underTest.fetchTodaysReleaseForUser(USER, true);
+
+      // then
+      assertThat(result).containsAll(releases);
+    }
+
+    @Test
+    @DisplayName("reissues are not returned if configured")
+    void test_reissues_not_returned() {
+      // given
+      var defaultRelease = ReleaseDtoFactory.createDefault();
+      var reissue = ReleaseDtoFactory.createDefault();
+      reissue.setReissue(true);
+      var releases = List.of(defaultRelease, reissue);
+      doReturn(List.of(ArtistDtoFactory.createDefault())).when(followArtistService).getFollowedArtistsOfUser(any());
+      doReturn(releases).when(releaseService).findAllReleases(anyList(), any());
+
+      // when
+      var result = underTest.fetchTodaysReleaseForUser(USER, false);
 
       // then
       assertThat(result).containsExactly(defaultRelease);
@@ -234,7 +308,7 @@ class NotificationReleaseCollectorTest implements WithAssertions {
     @DisplayName("followArtistService is called")
     void test_follow_artist_service_called() {
       // when
-      underTest.fetchTodaysAnnouncementsForUser(USER);
+      underTest.fetchTodaysAnnouncementsForUser(USER, false);
 
       // then
       verify(followArtistService).getFollowedArtistsOfUser(USER);
@@ -252,7 +326,7 @@ class NotificationReleaseCollectorTest implements WithAssertions {
       doReturn(List.of(ReleaseDtoFactory.withAnnouncementDate(now))).when(releaseService).findAllReleases(anyList(), any());
 
       // when
-      underTest.fetchTodaysAnnouncementsForUser(USER);
+      underTest.fetchTodaysAnnouncementsForUser(USER, false);
 
       // then
       verify(releaseService).findAllReleases(eq(List.of(followedArtist.getArtistName())), argumentCaptor.capture());
@@ -268,7 +342,7 @@ class NotificationReleaseCollectorTest implements WithAssertions {
       doReturn(Collections.emptyList()).when(followArtistService).getFollowedArtistsOfUser(any());
 
       // when
-      underTest.fetchTodaysAnnouncementsForUser(USER);
+      underTest.fetchTodaysAnnouncementsForUser(USER, false);
 
       // then
       verifyNoInteractions(releaseService);
@@ -288,7 +362,7 @@ class NotificationReleaseCollectorTest implements WithAssertions {
       List<ReleaseDto> result;
       try (MockedStatic<LocalDate> mock = mockStatic(LocalDate.class)) {
         mock.when(LocalDate::now).thenReturn(now);
-        result = underTest.fetchTodaysAnnouncementsForUser(USER);
+        result = underTest.fetchTodaysAnnouncementsForUser(USER, false);
       }
 
       // then
@@ -311,7 +385,53 @@ class NotificationReleaseCollectorTest implements WithAssertions {
       List<ReleaseDto> result;
       try (MockedStatic<LocalDate> mock = mockStatic(LocalDate.class)) {
         mock.when(LocalDate::now).thenReturn(now);
-        result = underTest.fetchTodaysAnnouncementsForUser(USER);
+        result = underTest.fetchTodaysAnnouncementsForUser(USER, false);
+      }
+
+      // then
+      assertThat(result).containsExactly(todaysAnnouncement);
+    }
+
+    @Test
+    @DisplayName("reissues are returned if configured")
+    void test_reissues_returned() {
+      // given
+      var now = LocalDate.now();
+      var todaysAnnouncement = ReleaseDtoFactory.withAnnouncementDate(now);
+      var reissue = ReleaseDtoFactory.withAnnouncementDate(now);
+      reissue.setReissue(true);
+      var releases = List.of(todaysAnnouncement, ReleaseDtoFactory.withAnnouncementDate(now.minusDays(1)), reissue);
+      doReturn(List.of(ArtistDtoFactory.createDefault())).when(followArtistService).getFollowedArtistsOfUser(any());
+      doReturn(releases).when(releaseService).findAllReleases(anyList(), any());
+
+      // when
+      List<ReleaseDto> result;
+      try (MockedStatic<LocalDate> mock = mockStatic(LocalDate.class)) {
+        mock.when(LocalDate::now).thenReturn(now);
+        result = underTest.fetchTodaysAnnouncementsForUser(USER, true);
+      }
+
+      // then
+      assertThat(result).containsAll(List.of(todaysAnnouncement, reissue));
+    }
+
+    @Test
+    @DisplayName("reissues are not returned if configured")
+    void test_reissues_not_returned() {
+      // given
+      var now = LocalDate.now();
+      var todaysAnnouncement = ReleaseDtoFactory.withAnnouncementDate(now);
+      var reissue = ReleaseDtoFactory.withAnnouncementDate(now);
+      reissue.setReissue(true);
+      var releases = List.of(todaysAnnouncement, ReleaseDtoFactory.withAnnouncementDate(now.minusDays(1)), reissue);
+      doReturn(List.of(ArtistDtoFactory.createDefault())).when(followArtistService).getFollowedArtistsOfUser(any());
+      doReturn(releases).when(releaseService).findAllReleases(anyList(), any());
+
+      // when
+      List<ReleaseDto> result;
+      try (MockedStatic<LocalDate> mock = mockStatic(LocalDate.class)) {
+        mock.when(LocalDate::now).thenReturn(now);
+        result = underTest.fetchTodaysAnnouncementsForUser(USER, false);
       }
 
       // then

--- a/webapp/src/test/java/rocks/metaldetector/service/notification/messaging/NotificationSchedulerTest.java
+++ b/webapp/src/test/java/rocks/metaldetector/service/notification/messaging/NotificationSchedulerTest.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -83,13 +84,13 @@ class NotificationSchedulerTest implements WithAssertions {
       doReturn(List.of(notificationConfig)).when(notificationConfigRepository).findAllActive();
       doReturn(mock(NotificationSender.class)).when(notificationSenderSupplier).apply(any());
       doReturn(new NotificationReleaseCollector.ReleaseContainer(Collections.emptyList(), Collections.emptyList()))
-          .when(notificationReleaseCollector).fetchReleasesForUserAndFrequency(any(), anyInt());
+          .when(notificationReleaseCollector).fetchReleasesForUserAndFrequency(any(), anyInt(), anyBoolean());
 
       // when
       underTest.notifyOnFrequency();
 
       // then
-      verify(notificationReleaseCollector).fetchReleasesForUserAndFrequency(notificationConfig.getUser(), notificationConfig.getFrequencyInWeeks());
+      verify(notificationReleaseCollector).fetchReleasesForUserAndFrequency(notificationConfig.getUser(), notificationConfig.getFrequencyInWeeks(), notificationConfig.getNotifyReissues());
     }
 
     @Test
@@ -99,7 +100,7 @@ class NotificationSchedulerTest implements WithAssertions {
       doReturn(List.of(notificationConfig)).when(notificationConfigRepository).findAllActive();
       doReturn(mock(NotificationSender.class)).when(notificationSenderSupplier).apply(any());
       doReturn(new NotificationReleaseCollector.ReleaseContainer(List.of(ReleaseDtoFactory.createDefault()), Collections.emptyList()))
-          .when(notificationReleaseCollector).fetchReleasesForUserAndFrequency(any(), anyInt());
+          .when(notificationReleaseCollector).fetchReleasesForUserAndFrequency(any(), anyInt(), anyBoolean());
 
       // when
       underTest.notifyOnFrequency();
@@ -116,7 +117,7 @@ class NotificationSchedulerTest implements WithAssertions {
       doReturn(List.of(notificationConfig)).when(notificationConfigRepository).findAllActive();
       doReturn(notificationServiceMock).when(notificationSenderSupplier).apply(any());
       doReturn(new NotificationReleaseCollector.ReleaseContainer(Collections.emptyList(), Collections.emptyList()))
-          .when(notificationReleaseCollector).fetchReleasesForUserAndFrequency(any(), anyInt());
+          .when(notificationReleaseCollector).fetchReleasesForUserAndFrequency(any(), anyInt(), anyBoolean());
 
       // when
       underTest.notifyOnFrequency();
@@ -136,7 +137,7 @@ class NotificationSchedulerTest implements WithAssertions {
       doReturn(List.of(notificationConfig)).when(notificationConfigRepository).findAllActive();
       doReturn(notificationServiceMock).when(notificationSenderSupplier).apply(any());
       doReturn(new NotificationReleaseCollector.ReleaseContainer(upcomingReleases, recentReleases))
-          .when(notificationReleaseCollector).fetchReleasesForUserAndFrequency(any(), anyInt());
+          .when(notificationReleaseCollector).fetchReleasesForUserAndFrequency(any(), anyInt(), anyBoolean());
 
       // when
       underTest.notifyOnFrequency();
@@ -153,7 +154,7 @@ class NotificationSchedulerTest implements WithAssertions {
       doReturn(List.of(notificationConfig)).when(notificationConfigRepository).findAllActive();
       doReturn(mock(NotificationSender.class)).when(notificationSenderSupplier).apply(any());
       doReturn(new NotificationReleaseCollector.ReleaseContainer(Collections.emptyList(), Collections.emptyList()))
-          .when(notificationReleaseCollector).fetchReleasesForUserAndFrequency(any(), anyInt());
+          .when(notificationReleaseCollector).fetchReleasesForUserAndFrequency(any(), anyInt(), anyBoolean());
 
       // when
       LocalDate now = LocalDate.of(2000, 1, 1);
@@ -177,13 +178,13 @@ class NotificationSchedulerTest implements WithAssertions {
       doReturn(List.of(notificationConfig, notificationConfig2)).when(notificationConfigRepository).findAllActive();
       doReturn(notificationServiceMock).when(notificationSenderSupplier).apply(any());
       doReturn(new NotificationReleaseCollector.ReleaseContainer(List.of(ReleaseDtoFactory.createDefault()), Collections.emptyList()))
-          .when(notificationReleaseCollector).fetchReleasesForUserAndFrequency(any(), anyInt());
+          .when(notificationReleaseCollector).fetchReleasesForUserAndFrequency(any(), anyInt(), anyBoolean());
 
       // when
       underTest.notifyOnFrequency();
 
       // then
-      verify(notificationReleaseCollector, times(2)).fetchReleasesForUserAndFrequency(any(), anyInt());
+      verify(notificationReleaseCollector, times(2)).fetchReleasesForUserAndFrequency(any(), anyInt(), anyBoolean());
       verify(notificationSenderSupplier, times(2)).apply(any());
       verify(notificationConfigRepository, times(2)).save(any());
       verify(notificationServiceMock, times(2)).sendFrequencyMessage(any(), any(), any());
@@ -231,13 +232,13 @@ class NotificationSchedulerTest implements WithAssertions {
       // given
       doReturn(List.of(notificationConfig)).when(notificationConfigRepository).findAllActive();
       doReturn(mock(NotificationSender.class)).when(notificationSenderSupplier).apply(any());
-      doReturn(Collections.emptyList()).when(notificationReleaseCollector).fetchTodaysReleaseForUser(any());
+      doReturn(Collections.emptyList()).when(notificationReleaseCollector).fetchTodaysReleaseForUser(any(), anyBoolean());
 
       // when
       underTest.notifyOnReleaseDate();
 
       // then
-      verify(notificationReleaseCollector).fetchTodaysReleaseForUser(notificationConfig.getUser());
+      verify(notificationReleaseCollector).fetchTodaysReleaseForUser(notificationConfig.getUser(), notificationConfig.getNotifyReissues());
     }
 
     @Test
@@ -246,7 +247,7 @@ class NotificationSchedulerTest implements WithAssertions {
       // given
       doReturn(List.of(notificationConfig)).when(notificationConfigRepository).findAllActive();
       doReturn(mock(NotificationSender.class)).when(notificationSenderSupplier).apply(any());
-      doReturn(List.of(ReleaseDtoFactory.createDefault())).when(notificationReleaseCollector).fetchTodaysReleaseForUser(any());
+      doReturn(List.of(ReleaseDtoFactory.createDefault())).when(notificationReleaseCollector).fetchTodaysReleaseForUser(any(), anyBoolean());
 
       // when
       underTest.notifyOnReleaseDate();
@@ -262,7 +263,7 @@ class NotificationSchedulerTest implements WithAssertions {
       var notificationServiceMock = mock(NotificationSender.class);
       doReturn(List.of(notificationConfig)).when(notificationConfigRepository).findAllActive();
       doReturn(notificationServiceMock).when(notificationSenderSupplier).apply(any());
-      doReturn(Collections.emptyList()).when(notificationReleaseCollector).fetchTodaysReleaseForUser(any());
+      doReturn(Collections.emptyList()).when(notificationReleaseCollector).fetchTodaysReleaseForUser(any(), anyBoolean());
 
       // when
       underTest.notifyOnReleaseDate();
@@ -280,7 +281,7 @@ class NotificationSchedulerTest implements WithAssertions {
       var todaysReleases = List.of(ReleaseDtoFactory.createDefault());
       doReturn(List.of(notificationConfig)).when(notificationConfigRepository).findAllActive();
       doReturn(notificationServiceMock).when(notificationSenderSupplier).apply(any());
-      doReturn(todaysReleases).when(notificationReleaseCollector).fetchTodaysReleaseForUser(any());
+      doReturn(todaysReleases).when(notificationReleaseCollector).fetchTodaysReleaseForUser(any(), anyBoolean());
 
       // when
       underTest.notifyOnReleaseDate();
@@ -297,13 +298,13 @@ class NotificationSchedulerTest implements WithAssertions {
       var notificationServiceMock = mock(NotificationSender.class);
       doReturn(List.of(notificationConfig, notificationConfig2)).when(notificationConfigRepository).findAllActive();
       doReturn(notificationServiceMock).when(notificationSenderSupplier).apply(any());
-      doReturn(List.of(ReleaseDtoFactory.createDefault())).when(notificationReleaseCollector).fetchTodaysReleaseForUser(any());
+      doReturn(List.of(ReleaseDtoFactory.createDefault())).when(notificationReleaseCollector).fetchTodaysReleaseForUser(any(), anyBoolean());
 
       // when
       underTest.notifyOnReleaseDate();
 
       // then
-      verify(notificationReleaseCollector, times(2)).fetchTodaysReleaseForUser(any());
+      verify(notificationReleaseCollector, times(2)).fetchTodaysReleaseForUser(any(), anyBoolean());
       verify(notificationSenderSupplier, times(2)).apply(any());
       verify(notificationServiceMock, times(2)).sendReleaseDateMessage(any(), any());
     }
@@ -350,13 +351,13 @@ class NotificationSchedulerTest implements WithAssertions {
       // given
       doReturn(List.of(notificationConfig)).when(notificationConfigRepository).findAllActive();
       doReturn(mock(NotificationSender.class)).when(notificationSenderSupplier).apply(any());
-      doReturn(Collections.emptyList()).when(notificationReleaseCollector).fetchTodaysAnnouncementsForUser(any());
+      doReturn(Collections.emptyList()).when(notificationReleaseCollector).fetchTodaysAnnouncementsForUser(any(), anyBoolean());
 
       // when
       underTest.notifyOnAnnouncementDate();
 
       // then
-      verify(notificationReleaseCollector).fetchTodaysAnnouncementsForUser(notificationConfig.getUser());
+      verify(notificationReleaseCollector).fetchTodaysAnnouncementsForUser(notificationConfig.getUser(), notificationConfig.getNotifyReissues());
     }
 
     @Test
@@ -365,7 +366,7 @@ class NotificationSchedulerTest implements WithAssertions {
       // given
       doReturn(List.of(notificationConfig)).when(notificationConfigRepository).findAllActive();
       doReturn(mock(NotificationSender.class)).when(notificationSenderSupplier).apply(any());
-      doReturn(List.of(ReleaseDtoFactory.createDefault())).when(notificationReleaseCollector).fetchTodaysAnnouncementsForUser(any());
+      doReturn(List.of(ReleaseDtoFactory.createDefault())).when(notificationReleaseCollector).fetchTodaysAnnouncementsForUser(any(), anyBoolean());
 
       // when
       underTest.notifyOnAnnouncementDate();
@@ -381,7 +382,7 @@ class NotificationSchedulerTest implements WithAssertions {
       var notificationServiceMock = mock(NotificationSender.class);
       doReturn(List.of(notificationConfig)).when(notificationConfigRepository).findAllActive();
       doReturn(notificationServiceMock).when(notificationSenderSupplier).apply(any());
-      doReturn(Collections.emptyList()).when(notificationReleaseCollector).fetchTodaysAnnouncementsForUser(any());
+      doReturn(Collections.emptyList()).when(notificationReleaseCollector).fetchTodaysAnnouncementsForUser(any(), anyBoolean());
 
       // when
       underTest.notifyOnAnnouncementDate();
@@ -399,7 +400,7 @@ class NotificationSchedulerTest implements WithAssertions {
       var todaysAnnouncements = List.of(ReleaseDtoFactory.createDefault());
       doReturn(List.of(notificationConfig)).when(notificationConfigRepository).findAllActive();
       doReturn(notificationServiceMock).when(notificationSenderSupplier).apply(any());
-      doReturn(todaysAnnouncements).when(notificationReleaseCollector).fetchTodaysAnnouncementsForUser(any());
+      doReturn(todaysAnnouncements).when(notificationReleaseCollector).fetchTodaysAnnouncementsForUser(any(), anyBoolean());
 
       // when
       underTest.notifyOnAnnouncementDate();
@@ -416,13 +417,13 @@ class NotificationSchedulerTest implements WithAssertions {
       var notificationServiceMock = mock(NotificationSender.class);
       doReturn(List.of(notificationConfig, notificationConfig2)).when(notificationConfigRepository).findAllActive();
       doReturn(notificationServiceMock).when(notificationSenderSupplier).apply(any());
-      doReturn(List.of(ReleaseDtoFactory.createDefault())).when(notificationReleaseCollector).fetchTodaysAnnouncementsForUser(any());
+      doReturn(List.of(ReleaseDtoFactory.createDefault())).when(notificationReleaseCollector).fetchTodaysAnnouncementsForUser(any(), anyBoolean());
 
       // when
       underTest.notifyOnAnnouncementDate();
 
       // then
-      verify(notificationReleaseCollector, times(2)).fetchTodaysAnnouncementsForUser(any());
+      verify(notificationReleaseCollector, times(2)).fetchTodaysAnnouncementsForUser(any(), anyBoolean());
       verify(notificationSenderSupplier, times(2)).apply(any());
       verify(notificationServiceMock, times(2)).sendAnnouncementDateMessage(any(), any());
     }

--- a/webapp/src/test/java/rocks/metaldetector/testutil/DtoFactory.java
+++ b/webapp/src/test/java/rocks/metaldetector/testutil/DtoFactory.java
@@ -239,6 +239,7 @@ public class DtoFactory {
           .artist(artistName)
           .albumTitle("Heavy Release")
           .releaseDate(LocalDate.now().plusDays(10))
+          .state("OK")
           .build();
     }
 
@@ -248,6 +249,7 @@ public class DtoFactory {
           .albumTitle("Heavy Release")
           .releaseDate(LocalDate.now().plusDays(10))
           .announcementDate(announcementDate)
+          .state("OK")
           .build();
     }
   }

--- a/webapp/src/test/java/rocks/metaldetector/web/transformer/NotificationConfigResponseTransformerTest.java
+++ b/webapp/src/test/java/rocks/metaldetector/web/transformer/NotificationConfigResponseTransformerTest.java
@@ -28,12 +28,14 @@ class NotificationConfigResponseTransformerTest implements WithAssertions {
         .notificationAtAnnouncementDate(true)
         .notificationAtReleaseDate(true)
         .notify(true)
+        .notifyReissues(true)
         .build();
     var expectedEmailConfig = EmailConfig.builder()
         .notify(true)
         .frequencyInWeeks(4)
         .notificationAtAnnouncementDate(true)
         .notificationAtReleaseDate(true)
+        .notifyReissues(true)
         .build();
 
     // when
@@ -53,6 +55,7 @@ class NotificationConfigResponseTransformerTest implements WithAssertions {
         .notificationAtAnnouncementDate(true)
         .notificationAtReleaseDate(true)
         .notify(true)
+        .notifyReissues(true)
         .build();
     var telegramConfigDto = TelegramConfigDto.builder()
         .registrationId(666)
@@ -65,6 +68,7 @@ class NotificationConfigResponseTransformerTest implements WithAssertions {
         .notificationAtReleaseDate(true)
         .registrationId(666)
         .notificationsActivated(true)
+        .notifyReissues(true)
         .build();
 
     // when
@@ -84,6 +88,7 @@ class NotificationConfigResponseTransformerTest implements WithAssertions {
         .notificationAtAnnouncementDate(true)
         .notify(true)
         .frequencyInWeeks(4)
+        .notifyReissues(true)
         .build();
     var expectedDto = NotificationConfigDto.builder()
         .channel("channel")
@@ -91,6 +96,7 @@ class NotificationConfigResponseTransformerTest implements WithAssertions {
         .notificationAtReleaseDate(true)
         .notificationAtAnnouncementDate(true)
         .frequencyInWeeks(4)
+        .notifyReissues(true)
         .build();
 
     // when


### PR DESCRIPTION
The mail/telegram notifications now only contain releases with state "OK". Also reissues are only returned if the notification config is configured that way.