### PR TITLE
Improve performance for fetching most expected releases

### DIFF
--- a/persistence/src/main/java/rocks/metaldetector/persistence/domain/artist/ArtistRepository.java
+++ b/persistence/src/main/java/rocks/metaldetector/persistence/domain/artist/ArtistRepository.java
@@ -19,7 +19,8 @@ public interface ArtistRepository extends JpaRepository<ArtistEntity, Long> {
   boolean existsByExternalIdAndSource(String externalId, ArtistSource source);
 
   @Query(value = "select a.artist_name as artistName, a.external_id as externalId, a.source as source," +
-                 "a.image_xs as imageXs, a.image_s as imageS, a.image_m as imageM, a.image_l as imageL " +
+                 "a.image_xs as imageXs, a.image_s as imageS, a.image_m as imageM, a.image_l as imageL, " +
+                 "count(a.external_id) as follower " +
                  "from follow_actions as fa left join artists as a on a.id = fa.artist_id " +
                  "group by a.artist_name, a.external_id, a.source, a.image_xs, a.image_s, a.image_m, a.image_l " +
                  "having count(a.id) >= :minFollower " +

--- a/persistence/src/main/java/rocks/metaldetector/persistence/domain/artist/TopArtist.java
+++ b/persistence/src/main/java/rocks/metaldetector/persistence/domain/artist/TopArtist.java
@@ -5,4 +5,5 @@ public interface TopArtist extends MultipleSizeImages {
   String getExternalId();
   String getArtistName();
   ArtistSource getSource();
+  int getFollower();
 }

--- a/persistence/src/test/java/rocks/metaldetector/persistence/domain/artist/ArtistRepositoryIT.java
+++ b/persistence/src/test/java/rocks/metaldetector/persistence/domain/artist/ArtistRepositoryIT.java
@@ -160,6 +160,7 @@ class ArtistRepositoryIT extends BaseDataJpaTest implements WithAssertions {
     // then
     assertThat(result).hasSize(expectedSize);
     assertThat(result.get(0).getArtistName()).isEqualTo(artist3.getArtistName());
+    assertThat(result.get(0).getFollower()).isEqualTo(3);
     assertThat(result.get(0).getImageXs()).isEqualTo(artist3.getImageXs());
     assertThat(result.get(0).getImageS()).isEqualTo(artist3.getImageS());
     assertThat(result.get(0).getImageM()).isEqualTo(artist3.getImageM());
@@ -168,6 +169,7 @@ class ArtistRepositoryIT extends BaseDataJpaTest implements WithAssertions {
     assertThat(result.get(0).getSource().getDisplayName()).isEqualTo(artist3.getSource().getDisplayName());
 
     assertThat(result.get(1).getArtistName()).isEqualTo(artist2.getArtistName());
+    assertThat(result.get(1).getFollower()).isEqualTo(2);
     assertThat(result.get(1).getImageXs()).isEqualTo(artist2.getImageXs());
     assertThat(result.get(1).getImageS()).isEqualTo(artist2.getImageS());
     assertThat(result.get(1).getImageM()).isEqualTo(artist2.getImageM());

--- a/webapp/src/main/java/rocks/metaldetector/service/artist/transformer/ArtistDtoTransformer.java
+++ b/webapp/src/main/java/rocks/metaldetector/service/artist/transformer/ArtistDtoTransformer.java
@@ -45,6 +45,7 @@ public class ArtistDtoTransformer {
             .externalId(topArtist.getExternalId())
             .artistName(topArtist.getArtistName())
             .source(topArtist.getSource().getDisplayName())
+            .follower(topArtist.getFollower())
             .images(transformImages(topArtist))
             .build();
   }

--- a/webapp/src/main/java/rocks/metaldetector/service/summary/ArtistCollector.java
+++ b/webapp/src/main/java/rocks/metaldetector/service/summary/ArtistCollector.java
@@ -26,7 +26,6 @@ public class ArtistCollector {
   public List<ArtistDto> collectTopFollowedArtists(int minFollower) {
     return artistRepository.findTopArtists(minFollower).stream()
         .map(artistDtoTransformer::transformTopArtist)
-        .peek(artist -> artist.setFollower(artistRepository.countArtistFollower(artist.getExternalId())))
         .collect(Collectors.toList());
   }
 

--- a/webapp/src/main/java/rocks/metaldetector/service/summary/ReleaseCollector.java
+++ b/webapp/src/main/java/rocks/metaldetector/service/summary/ReleaseCollector.java
@@ -27,7 +27,6 @@ import static rocks.metaldetector.support.DetectorSort.Direction.DESC;
 public class ReleaseCollector {
 
   private final ReleaseService releaseService;
-  private final ArtistCollector artistCollector;
 
   public List<ReleaseDto> collectUpcomingReleases(List<ArtistDto> artists) {
     LocalDate tomorrow = LocalDate.now().plusDays(1);
@@ -43,8 +42,7 @@ public class ReleaseCollector {
     return collectReleases(artists, timeRange, sort);
   }
 
-  public List<ReleaseDto> collectTopReleases(TimeRange timeRange, int minFollower, int maxReleases) {
-    List<ArtistDto> artists = artistCollector.collectTopFollowedArtists(minFollower);
+  public List<ReleaseDto> collectTopReleases(TimeRange timeRange, List<ArtistDto> artists, int maxReleases) {
     Map<String, Integer> followersPerArtist = artists.stream()
         .collect(Collectors.groupingBy(artistDto -> artistDto.getArtistName().toLowerCase(),
                                        Collectors.summingInt(ArtistDto::getFollower)));

--- a/webapp/src/main/java/rocks/metaldetector/service/summary/SummaryServiceImpl.java
+++ b/webapp/src/main/java/rocks/metaldetector/service/summary/SummaryServiceImpl.java
@@ -29,19 +29,19 @@ public class SummaryServiceImpl implements SummaryService {
   @Override
   public SummaryResponse createSummaryResponse() {
     List<ArtistDto> currentUsersFollowedArtists = followArtistService.getFollowedArtistsOfCurrentUser();
-    List<ArtistDto> mostFollowedArtists = artistCollector.collectTopFollowedArtists(MIN_FOLLOWER).stream().limit(RESULT_LIMIT).collect(Collectors.toList());
+    List<ArtistDto> topFollowedArtists = artistCollector.collectTopFollowedArtists(MIN_FOLLOWER).stream().limit(RESULT_LIMIT).collect(Collectors.toList());
     List<ArtistDto> recentlyFollowedArtists = artistCollector.collectRecentlyFollowedArtists(RESULT_LIMIT);
 
     List<ReleaseDto> upcomingReleases = releaseCollector.collectUpcomingReleases(currentUsersFollowedArtists);
     List<ReleaseDto> recentReleases = releaseCollector.collectRecentReleases(currentUsersFollowedArtists);
 
     var now = LocalDate.now();
-    List<ReleaseDto> mostExpectedReleases = releaseCollector.collectTopReleases(new TimeRange(now, now.plusMonths(TIME_RANGE_MONTHS)), MIN_FOLLOWER, RESULT_LIMIT);
+    List<ReleaseDto> mostExpectedReleases = releaseCollector.collectTopReleases(new TimeRange(now, now.plusMonths(TIME_RANGE_MONTHS)), topFollowedArtists, RESULT_LIMIT);
 
     return SummaryResponse.builder()
         .upcomingReleases(upcomingReleases)
         .recentReleases(recentReleases)
-        .favoriteCommunityArtists(mostFollowedArtists)
+        .favoriteCommunityArtists(topFollowedArtists)
         .mostExpectedReleases(mostExpectedReleases)
         .recentlyFollowedArtists(recentlyFollowedArtists)
         .build();
@@ -49,6 +49,7 @@ public class SummaryServiceImpl implements SummaryService {
 
   @Override
   public List<ReleaseDto> findTopReleases(TimeRange timeRange, int minFollower, int maxReleases) {
-    return releaseCollector.collectTopReleases(timeRange, minFollower, maxReleases);
+    List<ArtistDto> topFollowedArtists = artistCollector.collectTopFollowedArtists(minFollower).stream().limit(RESULT_LIMIT).collect(Collectors.toList());
+    return releaseCollector.collectTopReleases(timeRange, topFollowedArtists, maxReleases);
   }
 }

--- a/webapp/src/test/java/rocks/metaldetector/service/artist/transformer/ArtistDtoTransformerTest.java
+++ b/webapp/src/test/java/rocks/metaldetector/service/artist/transformer/ArtistDtoTransformerTest.java
@@ -68,6 +68,7 @@ class ArtistDtoTransformerTest implements WithAssertions {
     TopArtist topArtist = mock(TopArtist.class);
     doReturn("artist").when(topArtist).getArtistName();
     doReturn(SPOTIFY).when(topArtist).getSource();
+    doReturn(666).when(topArtist).getFollower();
     doReturn("http://example.com/image-xs.jpg").when(topArtist).getImageXs();
     doReturn("http://example.com/image-s.jpg").when(topArtist).getImageS();
     doReturn("http://example.com/image-m.jpg").when(topArtist).getImageM();
@@ -79,6 +80,7 @@ class ArtistDtoTransformerTest implements WithAssertions {
 
     // then
     assertThat(result.getArtistName()).isEqualTo(topArtist.getArtistName());
+    assertThat(result.getFollower()).isEqualTo(topArtist.getFollower());
     assertThat(result.getImages().get(XS)).isEqualTo(topArtist.getImageXs());
     assertThat(result.getImages().get(S)).isEqualTo(topArtist.getImageS());
     assertThat(result.getImages().get(M)).isEqualTo(topArtist.getImageM());


### PR DESCRIPTION
I rewrote the database query to fetch the number of followers directly with the TopArtists instead of querying followers for every single artist. Also the `collectTopFollowedArtists()` method was called twice.