### PR TITLE
spotify logging

### DIFF
--- a/support/src/main/java/rocks/metaldetector/support/Endpoints.java
+++ b/support/src/main/java/rocks/metaldetector/support/Endpoints.java
@@ -46,18 +46,16 @@ public class Endpoints {
     public static final String SPOTIFY_SYNCHRONIZATION     = "/settings/spotify-synchronization";
     public static final String NOTIFICATION_SETTINGS       = "/settings/notification-settings";
     public static final String TEST                        = "/only-for-testing";
-    public static final String SPOTIFY_CALLBACK            = "/spotify-callback";
     public static final List<String> ALL_FRONTEND_PAGES    = List.of(HOME, ARTISTS, SETTINGS, PROFILE, RELEASES, MY_ARTISTS,
                                                                      BLOG, BLOG_POST_WE_ARE_ONLINE, BLOG_POST_FUTURE_PLANS, BLOG_POST_TOP_RELEASES_2020,
-                                                                     IMPRINT, PRIVACY_POLICY, STATUS, TEST, SPOTIFY_CALLBACK,ACCOUNT_DETAILS,
-                                                                     SPOTIFY_SYNCHRONIZATION,NOTIFICATION_SETTINGS);
+                                                                     IMPRINT, PRIVACY_POLICY, STATUS, TEST, ACCOUNT_DETAILS,
+                                                                     SPOTIFY_SYNCHRONIZATION, NOTIFICATION_SETTINGS);
   }
 
   public static class Rest {
     public static final String HOME                           = "/rest/v1/home";
     public static final String ARTISTS                        = "/rest/v1/artists";
     public static final String MY_ARTISTS                     = "/rest/v1/my-artists";
-    public static final String SPOTIFY_AUTHORIZATION          = "/rest/v1/spotify/auth";
     public static final String SPOTIFY_ARTIST_SYNCHRONIZATION = "/rest/v1/spotify/synchronize";
     public static final String SPOTIFY_SAVED_ARTISTS          = "/rest/v1/spotify/saved-artists";
     public static final String ALL_RELEASES                   = "/rest/v1/releases/all";

--- a/webapp/src/main/java/rocks/metaldetector/config/logging/LoggingConfig.java
+++ b/webapp/src/main/java/rocks/metaldetector/config/logging/LoggingConfig.java
@@ -8,8 +8,12 @@ import org.springframework.web.filter.CommonsRequestLoggingFilter;
 public class LoggingConfig {
 
   @Bean
-  public CommonsRequestLoggingFilter logFilter() {
+  public CommonsRequestLoggingFilter restLoggingFilter() {
     return new RestRequestLoggingFilter();
   }
 
+  @Bean
+  public CommonsRequestLoggingFilter spotifyLoggingFilter() {
+    return new SpotifyRequestLoggingFilter();
+  }
 }

--- a/webapp/src/main/java/rocks/metaldetector/config/logging/SpotifyRequestLoggingFilter.java
+++ b/webapp/src/main/java/rocks/metaldetector/config/logging/SpotifyRequestLoggingFilter.java
@@ -1,0 +1,37 @@
+package rocks.metaldetector.config.logging;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.springframework.web.filter.CommonsRequestLoggingFilter;
+import rocks.metaldetector.support.Endpoints;
+import rocks.metaldetector.support.infrastructure.WithSensitiveDataRemover;
+
+import javax.servlet.http.HttpServletRequest;
+
+public class SpotifyRequestLoggingFilter extends CommonsRequestLoggingFilter implements WithSensitiveDataRemover {
+
+  SpotifyRequestLoggingFilter() {
+    super.setIncludeQueryString(true);
+    super.setIncludePayload(true);
+    super.setIncludeClientInfo(true);
+    super.setMaxPayloadLength(10000);
+    super.setIncludeHeaders(false);
+    super.setAfterMessagePrefix("");
+  }
+
+  @Override
+  protected boolean shouldLog(HttpServletRequest request) {
+    var requestUri = request.getRequestURI().toLowerCase();
+    return requestUri.startsWith(Endpoints.Frontend.SPOTIFY_SYNCHRONIZATION);
+  }
+
+  @Override
+  protected void afterRequest(HttpServletRequest request, String message) {
+    try {
+      message = removeSensitiveDataFromPayload(message);
+      logger.info(message);
+    }
+    catch (JsonProcessingException e) {
+      logger.error(e);
+    }
+  }
+}

--- a/webapp/src/main/java/rocks/metaldetector/web/controller/mvc/SpotifySynchronizationController.java
+++ b/webapp/src/main/java/rocks/metaldetector/web/controller/mvc/SpotifySynchronizationController.java
@@ -17,9 +17,4 @@ public class SpotifySynchronizationController {
   public ModelAndView showSettings() {
     return new ModelAndView(ViewNames.Frontend.SPOTIFY_SYNCHRONIZATION);
   }
-
-  @GetMapping(path = Endpoints.Frontend.SPOTIFY_CALLBACK)
-  public ModelAndView handleSpotifyCallback() {
-    return new ModelAndView(ViewNames.Frontend.SPOTIFY_SYNCHRONIZATION);
-  }
 }

--- a/webapp/src/test/java/rocks/metaldetector/web/controller/mvc/SpotifySynchronizationControllerTest.java
+++ b/webapp/src/test/java/rocks/metaldetector/web/controller/mvc/SpotifySynchronizationControllerTest.java
@@ -15,12 +15,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 class SpotifySynchronizationControllerTest {
 
   private RestAssuredMockMvcUtils restAssuredUtils;
-  private RestAssuredMockMvcUtils callbackRestAssuredUtils;
 
   @BeforeEach
   void setup() {
     restAssuredUtils = new RestAssuredMockMvcUtils(Endpoints.Frontend.SPOTIFY_SYNCHRONIZATION);
-    callbackRestAssuredUtils = new RestAssuredMockMvcUtils(Endpoints.Frontend.SPOTIFY_SYNCHRONIZATION + Endpoints.Frontend.SPOTIFY_CALLBACK);
     RestAssuredMockMvc.standaloneSetup(new SpotifySynchronizationController());
   }
 
@@ -39,28 +37,6 @@ class SpotifySynchronizationControllerTest {
   void get_search_should_return_profile_view() {
     // when
     var validatableResponse = restAssuredUtils.doGet();
-
-    // then
-    validatableResponse.assertThat(view().name(ViewNames.Frontend.SPOTIFY_SYNCHRONIZATION))
-        .assertThat(model().size(0))
-        .assertThat(model().hasNoErrors());
-  }
-
-  @Test
-  @DisplayName("Requesting '" + Endpoints.Frontend.SPOTIFY_SYNCHRONIZATION + Endpoints.Frontend.SPOTIFY_CALLBACK + "' should be ok")
-  void get_callback_should_return_200() {
-    // when
-    var validatableResponse = callbackRestAssuredUtils.doGet();
-
-    // then
-    validatableResponse.assertThat(status().isOk());
-  }
-
-  @Test
-  @DisplayName("Requesting '" + Endpoints.Frontend.SPOTIFY_SYNCHRONIZATION + Endpoints.Frontend.SPOTIFY_CALLBACK + "' should return the spotify synchronization view")
-  void get_callback_should_return_profile_view() {
-    // when
-    var validatableResponse = callbackRestAssuredUtils.doGet();
 
     // then
     validatableResponse.assertThat(view().name(ViewNames.Frontend.SPOTIFY_SYNCHRONIZATION))


### PR DESCRIPTION
On local machine I have the following output during spotify connect:

```
2021-09-07 15:36:06,506 [http-nio-8080-exec-10] INFO  r.m.c.l.SpotifyRequestLoggingFilter - GET /settings/spotify-synchronization, client=0:0:0:0:0:0:0:1, session=B4C588DA7FC7873FFD637993C4DA637F, user=Administrator] 
2021-09-07 15:36:06,580 [http-nio-8080-exec-2] INFO  r.m.c.logging.RestRequestLoggingFilter - GET /rest/v1/oauth/spotify-user, client=0:0:0:0:0:0:0:1, session=B4C588DA7FC7873FFD637993C4DA637F, user=Administrator] 
```

The one with query parameter is not logged as it is not handled by one of our mvc controller. 

So, in prod we may should see the query params there.