### PR TITLE
Fix most expected sorting and artists followers

### DIFF
--- a/webapp/src/main/java/rocks/metaldetector/service/summary/ReleaseCollector.java
+++ b/webapp/src/main/java/rocks/metaldetector/service/summary/ReleaseCollector.java
@@ -49,9 +49,9 @@ public class ReleaseCollector {
     return collectReleases(artists, timeRange, new DetectorSort("artist", ASC)).stream()
         .sorted(Comparator.comparingInt(
                 (ReleaseDto release) -> followersPerArtist.get(release.getArtist().toLowerCase()))
-                    .reversed())
+                    .reversed()
+                    .thenComparing(ReleaseDto::getReleaseDate))
         .limit(maxReleases)
-        .sorted(Comparator.comparing(ReleaseDto::getReleaseDate))
         .collect(Collectors.toList());
   }
 

--- a/webapp/src/main/java/rocks/metaldetector/service/summary/SummaryServiceImpl.java
+++ b/webapp/src/main/java/rocks/metaldetector/service/summary/SummaryServiceImpl.java
@@ -18,7 +18,7 @@ import java.util.stream.Collectors;
 @AllArgsConstructor
 public class SummaryServiceImpl implements SummaryService {
 
-  public static final int MIN_FOLLOWER = 1;
+  public static final int MIN_FOLLOWER = 2;
   public static final int RESULT_LIMIT = 4;
   public static final int TIME_RANGE_MONTHS = 6;
 


### PR DESCRIPTION
I think I changed the min number of followers for local testing and just forgot 🤷‍♂️ Also the sorting should now be correct, when there are multiple releases with the same amount of followers, having the earliest releases first.