### PR TITLE
Refresh token is fetched if access token is expired

### DIFF
--- a/support/src/main/java/rocks/metaldetector/support/oauth/OAuth2AccessTokenAuthorizationCodeClient.java
+++ b/support/src/main/java/rocks/metaldetector/support/oauth/OAuth2AccessTokenAuthorizationCodeClient.java
@@ -1,9 +1,15 @@
 package rocks.metaldetector.support.oauth;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.client.OAuth2AuthorizeRequest;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
 import org.springframework.stereotype.Component;
+
+import java.time.Instant;
 
 @Component
 @RequiredArgsConstructor
@@ -11,16 +17,33 @@ public class OAuth2AccessTokenAuthorizationCodeClient implements OAuth2AccessTok
 
   private final OAuth2AuthorizedClientService oAuth2AuthorizedClientService;
   private final CurrentOAuthUserIdSupplier currentOAuthUserIdSupplier;
+  private final OAuth2AuthorizedClientManager oAuth2AuthorizedClientManager;
   private String registrationId;
 
   @Override
   public String getAccessToken() {
     String userId = currentOAuthUserIdSupplier.get();
     OAuth2AuthorizedClient authorizedClient = oAuth2AuthorizedClientService.loadAuthorizedClient(registrationId, userId);
-    if (authorizedClient == null || authorizedClient.getAccessToken() == null ||
-        authorizedClient.getAccessToken().getTokenValue() == null || authorizedClient.getAccessToken().getTokenValue().isEmpty()) {
-      throw new IllegalArgumentException("No access token for client '" + registrationId + "'");
+
+    if (authorizedClient == null || authorizedClient.getAccessToken().getExpiresAt() == null) {
+      throw new IllegalArgumentException("No access token for client '" + userId + "' and registrationId '" + registrationId + "'");
     }
+
+    if (authorizedClient.getAccessToken().getExpiresAt().isBefore(Instant.now())) {
+      Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+      OAuth2AuthorizeRequest request = OAuth2AuthorizeRequest
+          .withAuthorizedClient(authorizedClient)
+          .principal(authentication)
+          .build();
+      OAuth2AuthorizedClient reAuthorizedClient = oAuth2AuthorizedClientManager.authorize(request);
+
+      if (reAuthorizedClient == null) {
+        throw new IllegalArgumentException("No refreshed access token for client '" + userId + "' and registrationId '" + registrationId + "'");
+      }
+
+      return reAuthorizedClient.getAccessToken().getTokenValue();
+    }
+
     return authorizedClient.getAccessToken().getTokenValue();
   }
 

--- a/support/src/main/java/rocks/metaldetector/support/oauth/OAuth2ClientConfig.java
+++ b/support/src/main/java/rocks/metaldetector/support/oauth/OAuth2ClientConfig.java
@@ -21,6 +21,7 @@ public class OAuth2ClientConfig {
     OAuth2AuthorizedClientProvider authorizedClientProvider = OAuth2AuthorizedClientProviderBuilder.builder()
         .clientCredentials()
         .authorizationCode()
+        .refreshToken()
         .build();
     var manager = new DefaultOAuth2AuthorizedClientManager(clientRegistrationRepository, authorizedClientRepository);
     manager.setAuthorizedClientProvider(authorizedClientProvider);

--- a/support/src/test/java/rocks/metaldetector/support/oauth/OAuth2AccessTokenAuthorizationCodeClientTest.java
+++ b/support/src/test/java/rocks/metaldetector/support/oauth/OAuth2AccessTokenAuthorizationCodeClientTest.java
@@ -11,14 +11,25 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.client.OAuth2AuthorizeRequest;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.core.OAuth2AccessToken;
 
+import java.time.Instant;
 import java.util.stream.Stream;
 
+import static java.time.temporal.ChronoUnit.MINUTES;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
@@ -33,18 +44,21 @@ class OAuth2AccessTokenAuthorizationCodeClientTest implements WithAssertions {
   private OAuth2AuthorizedClientService oAuth2AuthorizedClientService;
 
   @Mock
+  private OAuth2AuthorizedClientManager oAuth2AuthorizedClientManager;
+
+  @Mock
   private CurrentOAuthUserIdSupplier currentOAuthUserIdSupplier;
 
   private OAuth2AccessTokenAuthorizationCodeClient underTest;
 
   @BeforeEach
   private void setup() {
-    underTest = new OAuth2AccessTokenAuthorizationCodeClient(oAuth2AuthorizedClientService, currentOAuthUserIdSupplier);
+    underTest = new OAuth2AccessTokenAuthorizationCodeClient(oAuth2AuthorizedClientService, currentOAuthUserIdSupplier, oAuth2AuthorizedClientManager);
   }
 
   @AfterEach
   private void tearDown() {
-    reset(oAuth2AuthorizedClientService, currentOAuthUserIdSupplier);
+    reset(oAuth2AuthorizedClientService, currentOAuthUserIdSupplier, oAuth2AuthorizedClientManager);
   }
 
   @DisplayName("Tests for service handling")
@@ -59,6 +73,7 @@ class OAuth2AccessTokenAuthorizationCodeClientTest implements WithAssertions {
       doReturn(authorizedClientMock).when(oAuth2AuthorizedClientService).loadAuthorizedClient(any(), any());
       doReturn(accessTokenMock).when(authorizedClientMock).getAccessToken();
       doReturn("token").when(accessTokenMock).getTokenValue();
+      doReturn(Instant.now().plus(1, MINUTES)).when(accessTokenMock).getExpiresAt();
     }
 
     @Test
@@ -115,6 +130,7 @@ class OAuth2AccessTokenAuthorizationCodeClientTest implements WithAssertions {
       doReturn(authorizedClientMock).when(oAuth2AuthorizedClientService).loadAuthorizedClient(any(), any());
       doReturn(accessTokenMock).when(authorizedClientMock).getAccessToken();
       doReturn(token).when(accessTokenMock).getTokenValue();
+      doReturn(Instant.now().plus(1, MINUTES)).when(accessTokenMock).getExpiresAt();
 
       // when
       String result = underTest.getAccessToken();
@@ -125,16 +141,15 @@ class OAuth2AccessTokenAuthorizationCodeClientTest implements WithAssertions {
     @ParameterizedTest
     @DisplayName("Exception is thrown for bad clients and tokens")
     @MethodSource("badClientInputProvider")
-    void test_exception_thrown_for_bad_clients_or_tokens(OAuth2AuthorizedClient client, OAuth2AccessToken accessToken, String token) {
+    void test_exception_thrown_for_bad_clients_or_tokens(OAuth2AuthorizedClient client, Instant instant) {
       // given
       var registrationId = "registrationId";
       underTest.setRegistrationId(registrationId);
       doReturn(client).when(oAuth2AuthorizedClientService).loadAuthorizedClient(any(), any());
       if (client != null) {
-        doReturn(accessToken).when(client).getAccessToken();
-        if (accessToken != null) {
-          doReturn(token).when(accessToken).getTokenValue();
-        }
+        var mockToken = mock(OAuth2AccessToken.class);
+        doReturn(mockToken).when(client).getAccessToken();
+        doReturn(instant).when(mockToken).getExpiresAt();
       }
 
       // when
@@ -147,11 +162,151 @@ class OAuth2AccessTokenAuthorizationCodeClientTest implements WithAssertions {
 
     private Stream<Arguments> badClientInputProvider() {
       return Stream.of(
-          Arguments.of(null, null, null),
-          Arguments.of(mock(OAuth2AuthorizedClient.class), null, null),
-          Arguments.of(mock(OAuth2AuthorizedClient.class), mock(OAuth2AccessToken.class), null),
-          Arguments.of(mock(OAuth2AuthorizedClient.class), mock(OAuth2AccessToken.class), "")
+          Arguments.of(null, null),
+          Arguments.of(mock(OAuth2AuthorizedClient.class), null)
       );
+    }
+  }
+
+  @DisplayName("Tests for refreshing the authorization")
+  @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+  @Nested
+  class RefreshTest {
+
+    private final OAuth2AuthorizedClient AUTHORIZED_CLIENT_MOCK = mock(OAuth2AuthorizedClient.class);
+
+    @BeforeEach
+    void setup() {
+      var accessTokenMock = mock(OAuth2AccessToken.class);
+      doReturn(AUTHORIZED_CLIENT_MOCK).when(oAuth2AuthorizedClientService).loadAuthorizedClient(any(), any());
+      doReturn(accessTokenMock).when(AUTHORIZED_CLIENT_MOCK).getAccessToken();
+      doReturn(Instant.now().minus(1, MINUTES)).when(accessTokenMock).getExpiresAt();
+      doReturn(mock(ClientRegistration.class)).when(AUTHORIZED_CLIENT_MOCK).getClientRegistration();
+    }
+
+    @Test
+    @DisplayName("securityContextHolder is called for securityContext")
+    void test_security_context_holder_called() {
+      // given
+      var securityContextMock = mock(SecurityContext.class);
+      doReturn(mock(Authentication.class)).when(securityContextMock).getAuthentication();
+      var reauthorizedClientMock = mock(OAuth2AuthorizedClient.class);
+      var reauthorizedAccessTokenMock = mock(OAuth2AccessToken.class);
+      doReturn(reauthorizedClientMock).when(oAuth2AuthorizedClientManager).authorize(any());
+      doReturn(reauthorizedAccessTokenMock).when(reauthorizedClientMock).getAccessToken();
+
+      try (MockedStatic<SecurityContextHolder> securityContextHolderMock = Mockito.mockStatic(SecurityContextHolder.class)) {
+        // given
+        securityContextHolderMock.when(SecurityContextHolder::getContext).thenReturn(securityContextMock);
+
+        // when
+        underTest.getAccessToken();
+
+        // then
+        securityContextHolderMock.verify(SecurityContextHolder::getContext);
+      }
+    }
+
+    @Test
+    @DisplayName("securityContext is called for current authentication")
+    void test_security_context_called() {
+      // given
+      var securityContextMock = mock(SecurityContext.class);
+      doReturn(mock(Authentication.class)).when(securityContextMock).getAuthentication();
+      var reauthorizedClientMock = mock(OAuth2AuthorizedClient.class);
+      var reauthorizedAccessTokenMock = mock(OAuth2AccessToken.class);
+      doReturn(reauthorizedClientMock).when(oAuth2AuthorizedClientManager).authorize(any());
+      doReturn(reauthorizedAccessTokenMock).when(reauthorizedClientMock).getAccessToken();
+
+      try (MockedStatic<SecurityContextHolder> securityContextHolderMock = Mockito.mockStatic(SecurityContextHolder.class)) {
+        // given
+        securityContextHolderMock.when(SecurityContextHolder::getContext).thenReturn(securityContextMock);
+
+        // when
+        underTest.getAccessToken();
+      }
+
+      // then
+      verify(securityContextMock).getAuthentication();
+    }
+
+    @Test
+    @DisplayName("authorizedClientManager is called to reauthenticate client")
+    void test_manager_called() {
+      // given
+      ArgumentCaptor<OAuth2AuthorizeRequest> argumentCaptor = ArgumentCaptor.forClass(OAuth2AuthorizeRequest.class);
+      var securityContextMock = mock(SecurityContext.class);
+      var authenticationMock = mock(Authentication.class);
+      doReturn(authenticationMock).when(securityContextMock).getAuthentication();
+      var reauthorizedClientMock = mock(OAuth2AuthorizedClient.class);
+      var reauthorizedAccessTokenMock = mock(OAuth2AccessToken.class);
+      doReturn(reauthorizedClientMock).when(oAuth2AuthorizedClientManager).authorize(any());
+      doReturn(reauthorizedAccessTokenMock).when(reauthorizedClientMock).getAccessToken();
+
+      try (MockedStatic<SecurityContextHolder> securityContextHolderMock = Mockito.mockStatic(SecurityContextHolder.class)) {
+        // given
+        securityContextHolderMock.when(SecurityContextHolder::getContext).thenReturn(securityContextMock);
+
+        // when
+        underTest.getAccessToken();
+      }
+
+      // then
+      verify(oAuth2AuthorizedClientManager).authorize(argumentCaptor.capture());
+      OAuth2AuthorizeRequest capturedRequest = argumentCaptor.getValue();
+
+      assertThat(capturedRequest.getAuthorizedClient()).isEqualTo(AUTHORIZED_CLIENT_MOCK);
+      assertThat(capturedRequest.getPrincipal()).isEqualTo(authenticationMock);
+    }
+
+    @Test
+    @DisplayName("refreshed token is returned if present")
+    void test_refreshed_token_returned() {
+      // given
+      var securityContextMock = mock(SecurityContext.class);
+      var expectedToken = "reauthorizedToken";
+      String result;
+      doReturn(mock(Authentication.class)).when(securityContextMock).getAuthentication();
+      var reauthorizedClientMock = mock(OAuth2AuthorizedClient.class);
+      var reauthorizedAccessTokenMock = mock(OAuth2AccessToken.class);
+      doReturn(reauthorizedClientMock).when(oAuth2AuthorizedClientManager).authorize(any());
+      doReturn(reauthorizedAccessTokenMock).when(reauthorizedClientMock).getAccessToken();
+      doReturn(expectedToken).when(reauthorizedAccessTokenMock).getTokenValue();
+
+      try (MockedStatic<SecurityContextHolder> securityContextHolderMock = Mockito.mockStatic(SecurityContextHolder.class)) {
+        // given
+        securityContextHolderMock.when(SecurityContextHolder::getContext).thenReturn(securityContextMock);
+
+        // when
+        result = underTest.getAccessToken();
+      }
+
+      // then
+      assertThat(result).isEqualTo(expectedToken);
+    }
+
+    @Test
+    @DisplayName("Exception is thrown for bad client")
+    void test_exception_thrown_for_bad_clients_or_tokens() {
+      // given
+      var registrationId = "registrationId";
+      underTest.setRegistrationId(registrationId);
+      doReturn(null).when(oAuth2AuthorizedClientManager).authorize(any());
+      var securityContextMock = mock(SecurityContext.class);
+      doReturn(mock(Authentication.class)).when(securityContextMock).getAuthentication();
+      Throwable throwable;
+
+      try (MockedStatic<SecurityContextHolder> securityContextHolderMock = Mockito.mockStatic(SecurityContextHolder.class)) {
+        // given
+        securityContextHolderMock.when(SecurityContextHolder::getContext).thenReturn(securityContextMock);
+
+        // when
+        throwable = catchThrowable(() ->underTest.getAccessToken());
+      }
+
+      // then
+      assertThat(throwable).isInstanceOf(IllegalArgumentException.class);
+      assertThat(throwable).hasMessageContaining(registrationId);
     }
   }
 }


### PR DESCRIPTION
Until now it just wasn't checked if the token is expired. If so the manager has to reauthenticate the current client. I tested a bit with a grace period but it seems that the token really has to be expired for the manager to take action and reauthenticate it. So there might be a short period of time that can lead to 401, but I think we can take that chance. Should have a look at the logs..