### PR TITLE
Most expected releases sorting and number of releases fixed

### DIFF
--- a/webapp/src/main/java/rocks/metaldetector/service/summary/ReleaseCollector.java
+++ b/webapp/src/main/java/rocks/metaldetector/service/summary/ReleaseCollector.java
@@ -11,6 +11,7 @@ import rocks.metaldetector.support.PageRequest;
 import rocks.metaldetector.support.TimeRange;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -26,20 +27,26 @@ import static rocks.metaldetector.support.DetectorSort.Direction.DESC;
 @AllArgsConstructor
 public class ReleaseCollector {
 
+  static final int PAGE_SIZE = 50;
+
   private final ReleaseService releaseService;
 
   public List<ReleaseDto> collectUpcomingReleases(List<ArtistDto> artists) {
     LocalDate tomorrow = LocalDate.now().plusDays(1);
     TimeRange timeRange = new TimeRange(tomorrow, tomorrow.plusMonths(TIME_RANGE_MONTHS));
     DetectorSort sort = new DetectorSort("releaseDate", ASC);
-    return collectReleases(artists, timeRange, sort);
+    return collectReleases(artists, timeRange, sort).stream()
+        .limit(RESULT_LIMIT)
+        .collect(Collectors.toList());
   }
 
   public List<ReleaseDto> collectRecentReleases(List<ArtistDto> artists) {
     LocalDate now = LocalDate.now();
     TimeRange timeRange = new TimeRange(now.minusMonths(TIME_RANGE_MONTHS), now);
     DetectorSort sort = new DetectorSort("releaseDate", DESC);
-    return collectReleases(artists, timeRange, sort);
+    return collectReleases(artists, timeRange, sort).stream()
+        .limit(RESULT_LIMIT)
+        .collect(Collectors.toList());
   }
 
   public List<ReleaseDto> collectTopReleases(TimeRange timeRange, List<ArtistDto> artists, int maxReleases) {
@@ -49,9 +56,9 @@ public class ReleaseCollector {
     return collectReleases(artists, timeRange, new DetectorSort("artist", ASC)).stream()
         .sorted(Comparator.comparingInt(
                 (ReleaseDto release) -> followersPerArtist.get(release.getArtist().toLowerCase()))
-                    .reversed()
-                    .thenComparing(ReleaseDto::getReleaseDate))
+                    .reversed())
         .limit(maxReleases)
+        .sorted(Comparator.comparing(ReleaseDto::getReleaseDate))
         .collect(Collectors.toList());
   }
 
@@ -61,8 +68,17 @@ public class ReleaseCollector {
     }
 
     List<String> artistNames = artists.stream().map(ArtistDto::getArtistName).collect(Collectors.toList());
-    PageRequest pageRequest = new PageRequest(1, RESULT_LIMIT, sort);
-    Page<ReleaseDto> releasePage = releaseService.findReleases(artistNames, timeRange, null, pageRequest);
-    return releasePage.getItems();
+
+    List<ReleaseDto> releases = new ArrayList<>();
+    int currentPage = 1;
+    Page<ReleaseDto> releasePage;
+
+    do {
+      PageRequest pageRequest = new PageRequest(currentPage, PAGE_SIZE, sort);
+      releasePage = releaseService.findReleases(artistNames, timeRange, null, pageRequest);
+      releases.addAll(releasePage.getItems());
+    } while (currentPage++ < releasePage.getPagination().getTotalPages());
+
+    return releases;
   }
 }

--- a/webapp/src/test/java/rocks/metaldetector/service/summary/ReleaseCollectorTest.java
+++ b/webapp/src/test/java/rocks/metaldetector/service/summary/ReleaseCollectorTest.java
@@ -3,6 +3,7 @@ package rocks.metaldetector.service.summary;
 import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -20,6 +21,8 @@ import rocks.metaldetector.testutil.DtoFactory.ReleaseDtoFactory;
 import java.time.LocalDate;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -27,6 +30,8 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static rocks.metaldetector.service.summary.ReleaseCollector.PAGE_SIZE;
 import static rocks.metaldetector.service.summary.SummaryServiceImpl.RESULT_LIMIT;
 import static rocks.metaldetector.service.summary.SummaryServiceImpl.TIME_RANGE_MONTHS;
 import static rocks.metaldetector.support.DetectorSort.Direction.ASC;
@@ -46,294 +51,411 @@ class ReleaseCollectorTest implements WithAssertions {
     reset(releaseService);
   }
 
-  @Test
-  @DisplayName("collecting upcoming releases does not call releaseService when no artists are given")
-  void test_upcoming_releases_does_not_call_release_service() {
-    // when
-    underTest.collectUpcomingReleases(Collections.emptyList());
+  @Nested
+  @DisplayName("Tests for upcoming releases")
+  class UpcomingTests {
 
-    // then
-    verifyNoInteractions(releaseService);
+    @Test
+    @DisplayName("collecting upcoming releases does not call releaseService when no artists are given")
+    void test_upcoming_releases_does_not_call_release_service() {
+      // when
+      underTest.collectUpcomingReleases(Collections.emptyList());
+
+      // then
+      verifyNoInteractions(releaseService);
+    }
+
+    @Test
+    @DisplayName("collecting upcoming releases calls releaseService with followed artists' names")
+    void test_upcoming_releases_calls_release_service_with_artist_names() {
+      // given
+      var expectedArtistNames = List.of("A");
+      var artists = List.of(ArtistDtoFactory.withName("A"));
+      doReturn(new Page<>(Collections.emptyList(), new Pagination())).when(releaseService).findReleases(any(), any(), any(), any());
+
+      // when
+      underTest.collectUpcomingReleases(artists);
+
+      // then
+      verify(releaseService).findReleases(eq(expectedArtistNames), any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("collecting upcoming releases calls releaseService with correct time range")
+    void test_upcoming_releases_calls_release_service_with_time_range() {
+      // given
+      var tomorrow = LocalDate.now().plusDays(1);
+      var expectedTimeRange = new TimeRange(tomorrow, tomorrow.plusMonths(TIME_RANGE_MONTHS));
+      var artists = List.of(ArtistDtoFactory.withName("A"));
+      doReturn(new Page<>(Collections.emptyList(), new Pagination())).when(releaseService).findReleases(any(), any(), any(), any());
+
+      // when
+      underTest.collectUpcomingReleases(artists);
+
+      // then
+      verify(releaseService).findReleases(any(), eq(expectedTimeRange), any(), any());
+    }
+
+    @Test
+    @DisplayName("collecting upcoming releases calls releaseService without query")
+    void test_upcoming_releases_calls_release_service_without_query() {
+      // given
+      var artists = List.of(ArtistDtoFactory.withName("A"));
+      doReturn(new Page<>(Collections.emptyList(), new Pagination())).when(releaseService).findReleases(any(), any(), any(), any());
+
+      // when
+      underTest.collectUpcomingReleases(artists);
+
+      // then
+      verify(releaseService).findReleases(any(), any(), eq(null), any());
+    }
+
+    @Test
+    @DisplayName("collecting upcoming releases calls releaseService with correct page request and sorting")
+    void test_upcoming_releases_calls_release_service_with_page_request() {
+      // given
+      var sorting = new DetectorSort("releaseDate", ASC);
+      var expectedPageRequest = new PageRequest(1, PAGE_SIZE, sorting);
+      var artists = List.of(ArtistDtoFactory.withName("A"));
+      doReturn(new Page<>(Collections.emptyList(), new Pagination())).when(releaseService).findReleases(any(), any(), any(), any());
+
+      // when
+      underTest.collectUpcomingReleases(artists);
+
+      // then
+      verify(releaseService).findReleases(any(), any(), any(), eq(expectedPageRequest));
+      verifyNoMoreInteractions(releaseService);
+    }
+
+    @Test
+    @DisplayName("collecting upcoming releases calls releaseService again if multiple pages are present")
+    void test_upcoming_releases_calls_release_service_again() {
+      // given
+      var sorting = new DetectorSort("releaseDate", ASC);
+      var expectedPageRequest1 = new PageRequest(1, PAGE_SIZE, sorting);
+      var expectedPageRequest2 = new PageRequest(2, PAGE_SIZE, sorting);
+      var artists = List.of(ArtistDtoFactory.withName("A"));
+      doReturn(new Page<>(Collections.emptyList(), new Pagination(2, 1, 1))).when(releaseService).findReleases(any(), any(), any(), any());
+
+      // when
+      underTest.collectUpcomingReleases(artists);
+
+      // then
+      verify(releaseService).findReleases(any(), any(), any(), eq(expectedPageRequest1));
+      verify(releaseService).findReleases(any(), any(), any(), eq(expectedPageRequest2));
+    }
+
+    @Test
+    @DisplayName("collecting upcoming releases returns list of releases")
+    void test_upcoming_returns_releases() {
+      // given
+      var artists = List.of(ArtistDtoFactory.withName("A"));
+      var releases = List.of(ReleaseDtoFactory.createDefault(), ReleaseDtoFactory.createDefault());
+      doReturn(new Page<>(releases, new Pagination())).when(releaseService).findReleases(any(), any(), any(), any());
+
+      // when
+      var result = underTest.collectUpcomingReleases(artists);
+
+      // then
+      assertThat(result).isEqualTo(releases);
+    }
+
+    @Test
+    @DisplayName("collecting upcoming releases limits returned releases")
+    void test_upcoming_limits_releases() {
+      // given
+      var artists = List.of(ArtistDtoFactory.withName("A"));
+      var releases = Stream.generate(ReleaseDtoFactory::createDefault).limit(RESULT_LIMIT + 1).collect(Collectors.toList());
+      doReturn(new Page<>(releases, new Pagination())).when(releaseService).findReleases(any(), any(), any(), any());
+
+      // when
+      var result = underTest.collectUpcomingReleases(artists);
+
+      // then
+      assertThat(result.size()).isEqualTo(RESULT_LIMIT);
+    }
   }
 
-  @Test
-  @DisplayName("collecting upcoming releases calls releaseService with followed artists' names")
-  void test_upcoming_releases_calls_release_service_with_artist_names() {
-    // given
-    var expectedArtistNames = List.of("A");
-    var artists = List.of(ArtistDtoFactory.withName("A"));
-    doReturn(new Page<>(Collections.emptyList(), new Pagination())).when(releaseService).findReleases(any(), any(), any(), any());
+  @Nested
+  @DisplayName("Tests for recent releases")
+  class RecentTests {
 
-    // when
-    underTest.collectUpcomingReleases(artists);
+    @Test
+    @DisplayName("collecting recent releases does not call releaseService when no artists are given")
+    void test_recent_releases_does_not_call_release_service() {
+      // when
+      underTest.collectRecentReleases(Collections.emptyList());
 
-    // then
-    verify(releaseService).findReleases(eq(expectedArtistNames), any(), any(), any());
+      // then
+      verifyNoInteractions(releaseService);
+    }
+
+    @Test
+    @DisplayName("collecting recent releases calls releaseService with followed artists' names")
+    void test_recent_releases_calls_release_service_with_artist_names() {
+      // given
+      var expectedArtistNames = List.of("A");
+      var artists = List.of(ArtistDtoFactory.withName("A"));
+      doReturn(new Page<>(Collections.emptyList(), new Pagination())).when(releaseService).findReleases(any(), any(), any(), any());
+
+      // when
+      underTest.collectRecentReleases(artists);
+
+      // then
+      verify(releaseService).findReleases(eq(expectedArtistNames), any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("collecting recent releases calls releaseService with correct time range")
+    void test_recent_releases_calls_release_service_with_time_range() {
+      // given
+      var now = LocalDate.now();
+      var expectedTimeRange = new TimeRange(now.minusMonths(TIME_RANGE_MONTHS), now);
+      var artists = List.of(ArtistDtoFactory.withName("A"));
+      doReturn(new Page<>(Collections.emptyList(), new Pagination())).when(releaseService).findReleases(any(), any(), any(), any());
+
+      // when
+      underTest.collectRecentReleases(artists);
+
+      // then
+      verify(releaseService).findReleases(any(), eq(expectedTimeRange), any(), any());
+    }
+
+    @Test
+    @DisplayName("collecting recent releases calls releaseService without query")
+    void test_recent_releases_calls_release_service_without_query() {
+      // given
+      var artists = List.of(ArtistDtoFactory.withName("A"));
+      doReturn(new Page<>(Collections.emptyList(), new Pagination())).when(releaseService).findReleases(any(), any(), any(), any());
+
+      // when
+      underTest.collectRecentReleases(artists);
+
+      // then
+      verify(releaseService).findReleases(any(), any(), eq(null), any());
+    }
+
+    @Test
+    @DisplayName("collecting recent releases calls releaseService with correct page request and sorting")
+    void test_recent_releases_calls_release_service_with_page_request() {
+      // given
+      var expectedSorting = new DetectorSort("releaseDate", DESC);
+      var expectedPageRequest = new PageRequest(1, PAGE_SIZE, expectedSorting);
+      var artists = List.of(ArtistDtoFactory.withName("A"));
+      doReturn(new Page<>(Collections.emptyList(), new Pagination())).when(releaseService).findReleases(any(), any(), any(), any());
+
+      // when
+      underTest.collectRecentReleases(artists);
+
+      // then
+      verify(releaseService).findReleases(any(), any(), any(), eq(expectedPageRequest));
+      verifyNoMoreInteractions(releaseService);
+    }
+
+    @Test
+    @DisplayName("collecting recent releases calls releaseService again if multiple pages are present")
+    void test_recent_releases_calls_release_service_again() {
+      // given
+      var sorting = new DetectorSort("releaseDate", DESC);
+      var expectedPageRequest1 = new PageRequest(1, PAGE_SIZE, sorting);
+      var expectedPageRequest2 = new PageRequest(2, PAGE_SIZE, sorting);
+      var artists = List.of(ArtistDtoFactory.withName("A"));
+      doReturn(new Page<>(Collections.emptyList(), new Pagination(2, 1, 1))).when(releaseService).findReleases(any(), any(), any(), any());
+
+      // when
+      underTest.collectRecentReleases(artists);
+
+      // then
+      verify(releaseService).findReleases(any(), any(), any(), eq(expectedPageRequest1));
+      verify(releaseService).findReleases(any(), any(), any(), eq(expectedPageRequest2));
+    }
+
+    @Test
+    @DisplayName("collecting recent releases returns list of releases")
+    void test_recent_returns_releases() {
+      // given
+      var artists = List.of(ArtistDtoFactory.withName("A"));
+      var releases = List.of(ReleaseDtoFactory.createDefault(), ReleaseDtoFactory.createDefault());
+      doReturn(new Page<>(releases, new Pagination())).when(releaseService).findReleases(any(), any(), any(), any());
+
+      // when
+      var result = underTest.collectRecentReleases(artists);
+
+      // then
+      assertThat(result).isEqualTo(releases);
+    }
+
+    @Test
+    @DisplayName("collecting recent releases limits returned releases")
+    void test_recent_limits_releases() {
+      // given
+      var artists = List.of(ArtistDtoFactory.withName("A"));
+      var releases = Stream.generate(ReleaseDtoFactory::createDefault).limit(RESULT_LIMIT + 1).collect(Collectors.toList());
+      doReturn(new Page<>(releases, new Pagination())).when(releaseService).findReleases(any(), any(), any(), any());
+
+      // when
+      var result = underTest.collectRecentReleases(artists);
+
+      // then
+      assertThat(result.size()).isEqualTo(RESULT_LIMIT);
+    }
   }
 
-  @Test
-  @DisplayName("collecting upcoming releases calls releaseService with correct time range")
-  void test_upcoming_releases_calls_release_service_with_time_range() {
-    // given
-    var tomorrow = LocalDate.now().plusDays(1);
-    var expectedTimeRange = new TimeRange(tomorrow, tomorrow.plusMonths(TIME_RANGE_MONTHS));
-    var artists = List.of(ArtistDtoFactory.withName("A"));
-    doReturn(new Page<>(Collections.emptyList(), new Pagination())).when(releaseService).findReleases(any(), any(), any(), any());
+  @Nested
+  @DisplayName("Tests for top releases")
+  class TopTests {
 
-    // when
-    underTest.collectUpcomingReleases(artists);
+    @Test
+    @DisplayName("collecting top releases does not call releaseService when no artists are given")
+    void test_top_releases_does_not_call_release_service() {
+      // when
+      underTest.collectTopReleases(new TimeRange(), Collections.emptyList(), 10);
 
-    // then
-    verify(releaseService).findReleases(any(), eq(expectedTimeRange), any(), any());
-  }
+      // then
+      verifyNoInteractions(releaseService);
+    }
 
-  @Test
-  @DisplayName("collecting upcoming releases calls releaseService without query")
-  void test_upcoming_releases_calls_release_service_without_query() {
-    // given
-    var artists = List.of(ArtistDtoFactory.withName("A"));
-    doReturn(new Page<>(Collections.emptyList(), new Pagination())).when(releaseService).findReleases(any(), any(), any(), any());
+    @Test
+    @DisplayName("collecting top releases calls releaseService with top followed artists' names")
+    void test_top_releases_calls_release_service_with_top_artist_names() {
+      // given
+      var expectedArtistNames = List.of("A");
+      var artists = List.of(ArtistDtoFactory.withName("A"));
+      doReturn(new Page<>(Collections.emptyList(), new Pagination())).when(releaseService).findReleases(any(), any(), any(), any());
 
-    // when
-    underTest.collectUpcomingReleases(artists);
+      // when
+      underTest.collectTopReleases(new TimeRange(), artists, 10);
 
-    // then
-    verify(releaseService).findReleases(any(), any(), eq(null), any());
-  }
+      // then
+      verify(releaseService).findReleases(eq(expectedArtistNames), any(), any(), any());
+    }
 
-  @Test
-  @DisplayName("collecting upcoming releases calls releaseService with correct page request and sorting")
-  void test_upcoming_releases_calls_release_service_with_page_request() {
-    // given
-    var sorting = new DetectorSort("releaseDate", ASC);
-    var expectedPageRequest = new PageRequest(1, RESULT_LIMIT, sorting);
-    var artists = List.of(ArtistDtoFactory.withName("A"));
-    doReturn(new Page<>(Collections.emptyList(), new Pagination())).when(releaseService).findReleases(any(), any(), any(), any());
+    @Test
+    @DisplayName("collecting top releases calls releaseService with given time range")
+    void test_top_releases_calls_release_service_with_time_range() {
+      // given
+      var now = LocalDate.now();
+      var timeRange = new TimeRange(now, now.plusDays(666));
+      var artists = List.of(ArtistDtoFactory.withName("A"));
+      doReturn(new Page<>(Collections.emptyList(), new Pagination())).when(releaseService).findReleases(any(), any(), any(), any());
 
-    // when
-    underTest.collectUpcomingReleases(artists);
+      // when
+      underTest.collectTopReleases(timeRange, artists, 10);
 
-    // then
-    verify(releaseService).findReleases(any(), any(), any(), eq(expectedPageRequest));
-  }
+      // then
+      verify(releaseService).findReleases(any(), eq(timeRange), any(), any());
+    }
 
-  @Test
-  @DisplayName("collecting upcoming releases returns list of releases")
-  void test_upcoming_returns_releases() {
-    // given
-    var artists = List.of(ArtistDtoFactory.withName("A"));
-    var releases = List.of(ReleaseDtoFactory.createDefault(), ReleaseDtoFactory.createDefault());
-    doReturn(new Page<>(releases, new Pagination())).when(releaseService).findReleases(any(), any(), any(), any());
+    @Test
+    @DisplayName("collecting top releases calls releaseService without query")
+    void test_top_releases_calls_release_service_without_query() {
+      // given
+      var artists = List.of(ArtistDtoFactory.withName("A"));
+      doReturn(new Page<>(Collections.emptyList(), new Pagination())).when(releaseService).findReleases(any(), any(), any(), any());
 
-    // when
-    var result = underTest.collectUpcomingReleases(artists);
+      // when
+      underTest.collectTopReleases(new TimeRange(), artists, 10);
 
-    // then
-    assertThat(result).isEqualTo(releases);
-  }
+      // then
+      verify(releaseService).findReleases(any(), any(), eq(null), any());
+    }
 
-  @Test
-  @DisplayName("collecting recent releases does not call releaseService when no artists are given")
-  void test_recent_releases_does_not_call_release_service() {
-    // when
-    underTest.collectRecentReleases(Collections.emptyList());
+    @Test
+    @DisplayName("collecting top releases calls releaseService with correct page request and sorting")
+    void test_top_releases_calls_release_service_with_page_request() {
+      // given
+      var sorting = new DetectorSort("artist", ASC);
+      var expectedPageRequest = new PageRequest(1, PAGE_SIZE, sorting);
+      var artists = List.of(ArtistDtoFactory.withName("A"));
+      doReturn(new Page<>(Collections.emptyList(), new Pagination())).when(releaseService).findReleases(any(), any(), any(), any());
 
-    // then
-    verifyNoInteractions(releaseService);
-  }
+      // when
+      underTest.collectTopReleases(new TimeRange(), artists, 10);
 
-  @Test
-  @DisplayName("collecting recent releases calls releaseService with followed artists' names")
-  void test_recent_releases_calls_release_service_with_artist_names() {
-    // given
-    var expectedArtistNames = List.of("A");
-    var artists = List.of(ArtistDtoFactory.withName("A"));
-    doReturn(new Page<>(Collections.emptyList(), new Pagination())).when(releaseService).findReleases(any(), any(), any(), any());
+      // then
+      verify(releaseService).findReleases(any(), any(), any(), eq(expectedPageRequest));
+      verifyNoMoreInteractions(releaseService);
+    }
 
-    // when
-    underTest.collectRecentReleases(artists);
+    @Test
+    @DisplayName("collecting top releases calls releaseService again if multiple pages are present")
+    void test_top_releases_calls_release_service_again() {
+      // given
+      var sorting = new DetectorSort("artist", ASC);
+      var expectedPageRequest1 = new PageRequest(1, PAGE_SIZE, sorting);
+      var expectedPageRequest2 = new PageRequest(2, PAGE_SIZE, sorting);
+      var artists = List.of(ArtistDtoFactory.withName("A"));
+      doReturn(new Page<>(Collections.emptyList(), new Pagination(2, 1, 1))).when(releaseService).findReleases(any(), any(), any(), any());
 
-    // then
-    verify(releaseService).findReleases(eq(expectedArtistNames), any(), any(), any());
-  }
+      // when
+      underTest.collectTopReleases(new TimeRange(), artists, 1);
 
-  @Test
-  @DisplayName("collecting recent releases calls releaseService with correct time range")
-  void test_recent_releases_calls_release_service_with_time_range() {
-    // given
-    var now = LocalDate.now();
-    var expectedTimeRange = new TimeRange(now.minusMonths(TIME_RANGE_MONTHS), now);
-    var artists = List.of(ArtistDtoFactory.withName("A"));
-    doReturn(new Page<>(Collections.emptyList(), new Pagination())).when(releaseService).findReleases(any(), any(), any(), any());
+      // then
+      verify(releaseService).findReleases(any(), any(), any(), eq(expectedPageRequest1));
+      verify(releaseService).findReleases(any(), any(), any(), eq(expectedPageRequest2));
+    }
 
-    // when
-    underTest.collectRecentReleases(artists);
+    @Test
+    @DisplayName("collecting top releases fetches releases with most followers first")
+    void test_top_releases_most_followed() {
+      // given
+      var artist1 = ArtistDtoFactory.withName("a");
+      var artist2 = ArtistDtoFactory.withName("b");
+      artist1.setFollower(5);
+      artist2.setFollower(10);
+      var release1 = ReleaseDtoFactory.withArtistName(artist1.getArtistName());
+      var release2 = ReleaseDtoFactory.withArtistName(artist2.getArtistName());
+      var artists = List.of(artist1, artist2);
+      doReturn(new Page<>(List.of(release2, release1), new Pagination())).when(releaseService).findReleases(any(), any(), any(), any());
 
-    // then
-    verify(releaseService).findReleases(any(), eq(expectedTimeRange), any(), any());
-  }
+      // when
+      var result = underTest.collectTopReleases(new TimeRange(), artists, 1);
 
-  @Test
-  @DisplayName("collecting recent releases calls releaseService without query")
-  void test_recent_releases_calls_release_service_without_query() {
-    // given
-    var artists = List.of(ArtistDtoFactory.withName("A"));
-    doReturn(new Page<>(Collections.emptyList(), new Pagination())).when(releaseService).findReleases(any(), any(), any(), any());
+      // then
+      assertThat(result).containsExactly(release2);
+    }
 
-    // when
-    underTest.collectRecentReleases(artists);
+    @Test
+    @DisplayName("collecting top releases sorts by release date")
+    void test_top_releases_sorted() {
+      // given
+      var artist1 = ArtistDtoFactory.withName("a");
+      var artist2 = ArtistDtoFactory.withName("b");
+      var release1 = ReleaseDtoFactory.withArtistName(artist1.getArtistName());
+      var release2 = ReleaseDtoFactory.withArtistName(artist2.getArtistName());
+      release2.setReleaseDate(LocalDate.now().minusDays(10));
+      var artists = List.of(artist1, artist2);
+      doReturn(new Page<>(List.of(release2, release1), new Pagination())).when(releaseService).findReleases(any(), any(), any(), any());
 
-    // then
-    verify(releaseService).findReleases(any(), any(), eq(null), any());
-  }
+      // when
+      var result = underTest.collectTopReleases(new TimeRange(), artists, 10);
 
-  @Test
-  @DisplayName("collecting recent releases calls releaseService with correct page request and sorting")
-  void test_recent_releases_calls_release_service_with_page_request() {
-    // given
-    var expectedSorting = new DetectorSort("releaseDate", DESC);
-    var expectedPageRequest = new PageRequest(1, RESULT_LIMIT, expectedSorting);
-    var artists = List.of(ArtistDtoFactory.withName("A"));
-    doReturn(new Page<>(Collections.emptyList(), new Pagination())).when(releaseService).findReleases(any(), any(), any(), any());
+      // then
+      assertThat(result).hasSize(2);
+      assertThat(result.get(0)).isEqualTo(release2);
+      assertThat(result.get(1)).isEqualTo(release1);
+    }
 
-    // when
-    underTest.collectRecentReleases(artists);
+    @Test
+    @DisplayName("collecting top releases limits to given value")
+    void test_top_releases_limited() {
+      // given
+      var maxReleases = 1;
+      var artist1 = ArtistDtoFactory.withName("a");
+      var artist2 = ArtistDtoFactory.withName("b");
+      artist1.setFollower(2);
+      artist2.setFollower(1);
+      var release1 = ReleaseDtoFactory.withArtistName(artist1.getArtistName());
+      var release2 = ReleaseDtoFactory.withArtistName(artist2.getArtistName());
+      var artists = List.of(artist1, artist2);
+      doReturn(new Page<>(List.of(release2, release1), new Pagination())).when(releaseService).findReleases(any(), any(), any(), any());
 
-    // then
-    verify(releaseService).findReleases(any(), any(), any(), eq(expectedPageRequest));
-  }
+      // when
+      var result = underTest.collectTopReleases(new TimeRange(), artists, maxReleases);
 
-  @Test
-  @DisplayName("collecting top releases does not call releaseService when no artists are given")
-  void test_top_releases_does_not_call_release_service() {
-    // when
-    underTest.collectTopReleases(new TimeRange(), Collections.emptyList(), 10);
-
-    // then
-    verifyNoInteractions(releaseService);
-  }
-
-  @Test
-  @DisplayName("collecting top releases calls releaseService with top followed artists' names")
-  void test_top_releases_calls_release_service_with_top_artist_names() {
-    // given
-    var expectedArtistNames = List.of("A");
-    var artists = List.of(ArtistDtoFactory.withName("A"));
-    doReturn(new Page<>(Collections.emptyList(), new Pagination())).when(releaseService).findReleases(any(), any(), any(), any());
-
-    // when
-    underTest.collectTopReleases(new TimeRange(), artists, 10);
-
-    // then
-    verify(releaseService).findReleases(eq(expectedArtistNames), any(), any(), any());
-  }
-
-  @Test
-  @DisplayName("collecting top releases calls releaseService with given time range")
-  void test_top_releases_calls_release_service_with_time_range() {
-    // given
-    var now = LocalDate.now();
-    var timeRange = new TimeRange(now, now.plusDays(666));
-    var artists = List.of(ArtistDtoFactory.withName("A"));
-    doReturn(new Page<>(Collections.emptyList(), new Pagination())).when(releaseService).findReleases(any(), any(), any(), any());
-
-    // when
-    underTest.collectTopReleases(timeRange, artists, 10);
-
-    // then
-    verify(releaseService).findReleases(any(), eq(timeRange), any(), any());
-  }
-
-  @Test
-  @DisplayName("collecting top releases calls releaseService without query")
-  void test_top_releases_calls_release_service_without_query() {
-    // given
-    var artists = List.of(ArtistDtoFactory.withName("A"));
-    doReturn(new Page<>(Collections.emptyList(), new Pagination())).when(releaseService).findReleases(any(), any(), any(), any());
-
-    // when
-    underTest.collectTopReleases(new TimeRange(), artists, 10);
-
-    // then
-    verify(releaseService).findReleases(any(), any(), eq(null), any());
-  }
-
-  @Test
-  @DisplayName("collecting top releases calls releaseService with correct page request and sorting")
-  void test_top_releases_calls_release_service_with_page_request() {
-    // given
-    var sorting = new DetectorSort("artist", ASC);
-    var expectedPageRequest = new PageRequest(1, RESULT_LIMIT, sorting);
-    var artists = List.of(ArtistDtoFactory.withName("A"));
-    doReturn(new Page<>(Collections.emptyList(), new Pagination())).when(releaseService).findReleases(any(), any(), any(), any());
-
-    // when
-    underTest.collectTopReleases(new TimeRange(), artists, 10);
-
-    // then
-    verify(releaseService).findReleases(any(), any(), any(), eq(expectedPageRequest));
-  }
-
-  @Test
-  @DisplayName("collecting top releases fetches releases with most followers first")
-  void test_top_releases_most_followed() {
-    // given
-    var artist1 = ArtistDtoFactory.withName("a");
-    var artist2 = ArtistDtoFactory.withName("b");
-    artist1.setFollower(5);
-    artist2.setFollower(10);
-    var release1 = ReleaseDtoFactory.withArtistName(artist1.getArtistName());
-    var release2 = ReleaseDtoFactory.withArtistName(artist2.getArtistName());
-    var artists = List.of(artist1, artist2);
-    doReturn(new Page<>(List.of(release2, release1), new Pagination())).when(releaseService).findReleases(any(), any(), any(), any());
-
-    // when
-    var result = underTest.collectTopReleases(new TimeRange(), artists, 1);
-
-    // then
-    assertThat(result).containsExactly(release2);
-  }
-
-  @Test
-  @DisplayName("collecting top releases sorts by release date")
-  void test_top_releases_sorted() {
-    // given
-    var artist1 = ArtistDtoFactory.withName("a");
-    var artist2 = ArtistDtoFactory.withName("b");
-    var release1 = ReleaseDtoFactory.withArtistName(artist1.getArtistName());
-    var release2 = ReleaseDtoFactory.withArtistName(artist2.getArtistName());
-    release2.setReleaseDate(LocalDate.now().minusDays(10));
-    var artists = List.of(artist1, artist2);
-    doReturn(new Page<>(List.of(release2, release1), new Pagination())).when(releaseService).findReleases(any(), any(), any(), any());
-
-    // when
-    var result = underTest.collectTopReleases(new TimeRange(), artists, 10);
-
-    // then
-    assertThat(result).hasSize(2);
-    assertThat(result.get(0)).isEqualTo(release2);
-    assertThat(result.get(1)).isEqualTo(release1);
-  }
-
-  @Test
-  @DisplayName("collecting top releases limits to given value")
-  void test_top_releases_limited() {
-    // given
-    var maxReleases = 1;
-    var artist1 = ArtistDtoFactory.withName("a");
-    var artist2 = ArtistDtoFactory.withName("b");
-    artist1.setFollower(2);
-    artist2.setFollower(1);
-    var release1 = ReleaseDtoFactory.withArtistName(artist1.getArtistName());
-    var release2 = ReleaseDtoFactory.withArtistName(artist2.getArtistName());
-    var artists = List.of(artist1, artist2);
-    doReturn(new Page<>(List.of(release2, release1), new Pagination())).when(releaseService).findReleases(any(), any(), any(), any());
-
-    // when
-    var result = underTest.collectTopReleases(new TimeRange(), artists, maxReleases);
-
-    // then
-    assertThat(result).hasSize(maxReleases);
-    assertThat(result).containsExactly(release1);
+      // then
+      assertThat(result).hasSize(maxReleases);
+      assertThat(result).containsExactly(release1);
+    }
   }
 }


### PR DESCRIPTION
The sorting should now finally be correct. Also now all pages are requested. This is also done for the upcoming and current releases, where it would not really be necessary, but for the sake or readability and for the three methods working the same way, it still is done (and then limited to the max number of releases).
Looked good when tested locally with the releases from prod.