### PR TITLE
Remove duplicate header

### DIFF
--- a/webapp/src/main/java/rocks/metaldetector/security/SecurityConfig.java
+++ b/webapp/src/main/java/rocks/metaldetector/security/SecurityConfig.java
@@ -24,7 +24,6 @@ import org.springframework.security.web.authentication.HttpStatusEntryPoint;
 import org.springframework.security.web.authentication.LoginUrlAuthenticationEntryPoint;
 import org.springframework.security.web.authentication.SavedRequestAwareAuthenticationSuccessHandler;
 import org.springframework.security.web.authentication.rememberme.JdbcTokenRepositoryImpl;
-import org.springframework.security.web.header.writers.ReferrerPolicyHeaderWriter;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import rocks.metaldetector.persistence.domain.user.UserRole;
 import rocks.metaldetector.security.handler.CustomAccessDeniedHandler;
@@ -119,10 +118,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
       .exceptionHandling()
         .accessDeniedHandler(new CustomAccessDeniedHandler(() -> SecurityContextHolder.getContext().getAuthentication()))
         .defaultAuthenticationEntryPointFor(new LoginUrlAuthenticationEntryPoint(Endpoints.Guest.LOGIN), new AntPathRequestMatcher(Endpoints.Guest.SLASH_INDEX))
-        .defaultAuthenticationEntryPointFor(new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED), new AntPathRequestMatcher(REST_ENDPOINTS))
-      .and()
-      .headers()
-        .referrerPolicy(ReferrerPolicyHeaderWriter.ReferrerPolicy.STRICT_ORIGIN_WHEN_CROSS_ORIGIN);
+        .defaultAuthenticationEntryPointFor(new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED), new AntPathRequestMatcher(REST_ENDPOINTS));
   }
 
   @Override


### PR DESCRIPTION
`referrer-policy | strict-origin-when-cross-origin` Header is already set on prod. There are some more duplicate headers but I'm not sure right now where they are set.. I guess Spring sets some of the automatically and some are set by the proxy. Maybe we could turn them of in Spring at some point..