### PR TITLE
fix docker network

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,10 @@ To start the application locally in default profile, the following preparatory a
 
 1. Run `docker-compose.yml` via command `docker-compose up -d --no-recreate`. This starts all peripheral docker containers that are needed locally to run the Metal Detector Application:
     - `detector-db`: The database for Metal Detector application (currently PostgreSQL)
-    - `butler-db`: The database for Metal Release Butler application
-    - `auth-db`: The database for Metal Detector auth application
     - `butler-app`: Metal Release Butler Spring Boot application
+    - `butler-db`: The database for Metal Release Butler application
     - `auth-app`: Metal Detector Auth Spring Boot application
+    - `auth-db`: The database for Metal Detector auth application
 
 2. Define the data source connection details in file `application.yml`:
     - `spring.datasource.username` (you have to use user `postgres`)
@@ -58,14 +58,20 @@ To start the application locally in default profile, the following preparatory a
    - `spring.security.oauth2.client.registration.google.client-id`
    - `spring.security.oauth2.client.registration.google.client-secret`
 
-6. Define remember-me secret (you can choose any value you want) in file `application.yml`:
-    - `security.remember-me-secret` for remember me functionality
+6. Deposit the Metal Detector client id and client secret (see environment variables of auth-app service in `docker-compose.yml`) in file `application.yml`:
+   - `spring.security.oauth2.client.registration.metal-release-butler-user.client-id`
+   - `spring.security.oauth2.client.registration.metal-release-butler-user.client-secret`
+   - `spring.security.oauth2.client.registration.metal-release-butler-admin.client-id`
+   - `spring.security.oauth2.client.registration.metal-release-butler-admin.client-secret`
 
-7. Define a dummy value for `telegram.bot-id` in file `application.yml`.
+7. Define remember-me secret (you can choose any value you want) in file `application.yml`:
+   - `security.remember-me-secret` for remember me functionality
 
-8. Compile the frontend initially. To do this you have to execute the following commands from the root directory of the project:
-    - `npm --prefix webapp/src/main/resources/static/ts/ install`
-    - `npm --prefix webapp/src/main/resources/static/ts/ run dev-build`
+8. Define a dummy value for `telegram.bot-id` in file `application.yml`.
+
+9. Compile the frontend initially. To do this you have to execute the following commands from the root directory of the project:
+   - `npm --prefix webapp/src/main/resources/static/ts/ install`
+   - `npm --prefix webapp/src/main/resources/static/ts/ run dev-build`
 
 It is also possible to define all mentioned connection details and secrets as environment variables. In this case no variables in `application.yml` need to be changed. The names of the environment variables are already in the `application.yml` file. You can  define the environment variables for example within a Run Configuration in IntelliJ.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,7 @@ services:
       ROCKS_METALDETECTOR_AUTHENTICATION_ENABLED: 'false'
     networks:
       - butler-network
+      - service-network
     volumes:
       - type: volume
         source: butler-image-volume
@@ -88,6 +89,7 @@ services:
       METAL_DETECTOR_ADMIN_CLIENT_SECRET: adminSecret
     networks:
       - auth-network
+      - service-network
     ports:
       - "9000:8080"
     restart: on-failure:3
@@ -111,3 +113,5 @@ networks:
     name: butler-network
   auth-network:
     name: auth-network
+  service-network:
+    name: service-network

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,10 +16,15 @@ services:
         target: /var/lib/postgresql/data
     ports:
       - "5432:5432"
-    restart: on-failure:3
+    deploy:
+      restart_policy:
+        condition: on-failure
+        delay: 5s
+        max_attempts: 3
+        window: 120s
 
   butler-db:
-    container_name: butler-db
+    container_name: detector-butler-db
     image: postgres:13.1-alpine
     environment:
       POSTGRES_PASSWORD: secret
@@ -33,7 +38,12 @@ services:
         target: /var/lib/postgresql/data
     ports:
       - "5433:5432"
-    restart: on-failure:3
+    deploy:
+      restart_policy:
+        condition: on-failure
+        delay: 5s
+        max_attempts: 3
+        window: 120s
 
   butler-app:
     container_name: butler-app
@@ -42,7 +52,6 @@ services:
       DATASOURCE_URL: jdbc:postgresql://butler-db:5432/metal-release-butler
       DATASOURCE_USERNAME: postgres
       DATASOURCE_PASSWORD: secret
-      ROCKS_METALDETECTOR_AUTHENTICATION_ENABLED: 'false'
     networks:
       - butler-network
       - service-network
@@ -55,10 +64,15 @@ services:
         target: /app/logs
     ports:
       - "8095:8080"
-    restart: on-failure:3
+    deploy:
+      restart_policy:
+        condition: on-failure
+        delay: 5s
+        max_attempts: 3
+        window: 120s
 
   auth-db:
-    container_name: auth-db
+    container_name: detector-auth-db
     image: postgres:13.1-alpine
     environment:
       POSTGRES_PASSWORD: secret
@@ -72,10 +86,15 @@ services:
         target: /var/lib/postgresql/data
     ports:
       - "5434:5432"
-    restart: on-failure:3
+    deploy:
+      restart_policy:
+        condition: on-failure
+        delay: 5s
+        max_attempts: 3
+        window: 120s
 
   auth-app:
-    container_name: auth-app
+    container_name: detector-auth-app
     image: metaldetector/metal-detector-auth
     environment:
       DATASOURCE_URL: jdbc:postgresql://auth-db:5432/metal-detector-auth
@@ -92,19 +111,24 @@ services:
       - service-network
     ports:
       - "9000:8080"
-    restart: on-failure:3
+    deploy:
+      restart_policy:
+        condition: on-failure
+        delay: 5s
+        max_attempts: 3
+        window: 120s
 
 volumes:
   detector-db-volume:
     name: detector-db
   butler-db-volume:
-    name: butler-db
+    name: detector-butler-db
   butler-image-volume:
-    name: butler-images
+    name: detector-butler-images
   butler-logs-volume:
-    name: butler-logs
+    name: detector-butler-logs
   auth-db-volume:
-    name: auth-db
+    name: detector-auth-db
 
 networks:
   detector-network:


### PR DESCRIPTION
the shared network works well for me. I have tested it as follows:

```shell
docker exec -it detector-auth-app
curl -X GET http://butler-app:8080/actuator/health
```

The current issuer uri is still a problem. 

Further:
- IntelliJ complains about the restart policy.
- I also decided to use some kind of namespace for the volumes here, because volumes with the same naming are also created by the Butler and sharing them is not so easy.
