### PR TITLE
Fixes the usage of oauth clients for scheduled tasks

### DIFF
--- a/butler/src/main/java/rocks/metaldetector/butler/client/transformer/ButlerSortTransformer.java
+++ b/butler/src/main/java/rocks/metaldetector/butler/client/transformer/ButlerSortTransformer.java
@@ -16,6 +16,9 @@ public class ButlerSortTransformer {
   private static final String DEFAULT_SORTING = "&sort=artist,ASC&sort=albumTitle,ASC";
 
   public String transform(DetectorSort sort) {
+    if (sort == null) {
+      return null;
+    }
     String sortParam = String.format("sort=%s,%s", FIELD_MAPPING.getOrDefault(sort.getField(), sort.getField()), sort.getDirection());
     return sortParam.concat(DEFAULT_SORTING);
   }

--- a/butler/src/main/java/rocks/metaldetector/butler/config/ButlerOAuth2ClientInterceptor.java
+++ b/butler/src/main/java/rocks/metaldetector/butler/config/ButlerOAuth2ClientInterceptor.java
@@ -18,6 +18,7 @@ public class ButlerOAuth2ClientInterceptor implements ClientHttpRequestIntercept
 
   protected static final String ADMINISTRATOR_AUTHORITY = "ROLE_ADMINISTRATOR";
   protected static final String USER_AUTHORITY = "ROLE_USER";
+  protected static final String ANONYMOUS_AUTHORITY = "ROLE_ANONYMOUS";
 
   private final OAuth2AccessTokenClient userTokenClient;
   private final OAuth2AccessTokenClient adminTokenClient;
@@ -37,7 +38,7 @@ public class ButlerOAuth2ClientInterceptor implements ClientHttpRequestIntercept
     if (grantedAuthorities.contains(ADMINISTRATOR_AUTHORITY)) {
       accessTokenValue = adminTokenClient.getAccessToken();
     }
-    else if (grantedAuthorities.contains(USER_AUTHORITY)) {
+    else if (grantedAuthorities.contains(USER_AUTHORITY) || grantedAuthorities.contains(ANONYMOUS_AUTHORITY)) {
       accessTokenValue = userTokenClient.getAccessToken();
     } else {
       throw new AccessDeniedException("No authorities present for principal '" + currentAuthentication.getName() + "'");

--- a/butler/src/test/java/rocks/metaldetector/butler/client/transformer/ButlerSortTransformerTest.java
+++ b/butler/src/test/java/rocks/metaldetector/butler/client/transformer/ButlerSortTransformerTest.java
@@ -2,6 +2,7 @@ package rocks.metaldetector.butler.client.transformer;
 
 import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -25,6 +26,16 @@ class ButlerSortTransformerTest implements WithAssertions {
 
     // then
     assertThat(result).isEqualTo(expected);
+  }
+
+  @Test
+  @DisplayName("transformer is nullsafe")
+  void test_nullsafe() {
+    // when
+    var result = underTest.transform(null);
+
+    // then
+    assertThat(result).isNull();
   }
 
   private static Stream<Arguments> fieldProvider() {

--- a/support/src/main/java/rocks/metaldetector/support/infrastructure/ApacheHttpClientConfig.java
+++ b/support/src/main/java/rocks/metaldetector/support/infrastructure/ApacheHttpClientConfig.java
@@ -17,7 +17,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.TaskScheduler;
-import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 
@@ -26,10 +25,10 @@ import java.time.Duration;
 import static java.util.concurrent.TimeUnit.MINUTES;
 
 @Configuration
-@EnableScheduling
 @Slf4j
 public class ApacheHttpClientConfig {
 
+  public static final String SCHEDULED_TASK_NAME_PREFIX = "threadPoolTaskScheduler";
   private static final int MAX_ROUTE_CONNECTIONS     = 40;
   private static final int MAX_TOTAL_CONNECTIONS     = 40;
   private static final int MAX_LOCALHOST_CONNECTIONS = 80;
@@ -94,7 +93,7 @@ public class ApacheHttpClientConfig {
   @Bean
   public TaskScheduler taskScheduler() {
     ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
-    scheduler.setThreadNamePrefix("idleMonitor");
+    scheduler.setThreadNamePrefix(SCHEDULED_TASK_NAME_PREFIX);
     scheduler.setPoolSize(5);
     return scheduler;
   }

--- a/support/src/main/java/rocks/metaldetector/support/oauth/OAuth2AccessTokenClient.java
+++ b/support/src/main/java/rocks/metaldetector/support/oauth/OAuth2AccessTokenClient.java
@@ -6,7 +6,6 @@ import org.springframework.context.annotation.Scope;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.client.OAuth2AuthorizeRequest;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
-import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
 import org.springframework.stereotype.Component;
@@ -24,7 +23,7 @@ public class OAuth2AccessTokenClient {
 
   static final long TOKEN_EXPIRATION_GRACE_PERIOD = 15;
 
-  private final OAuth2AuthorizedClientManager authorizedClientManager;
+  private final OAuth2ClientManagerProvider managerProvider;
   private final OAuth2AuthorizedClientService authorizedClientService;
   private final OAuth2AuthorizeRequestProvider authorizeRequestProvider;
   private final OAuth2AuthenticationProvider authenticationProvider;
@@ -40,7 +39,7 @@ public class OAuth2AccessTokenClient {
 
     if (isAuthorizationRequired(authorizedClient)) {
       OAuth2AuthorizeRequest authorizedRequest = authorizeRequestProvider.provideForGrant(authorizationGrantType, authorizedClient, registrationId);
-      authorizedClient = authorizedClientManager.authorize(authorizedRequest);
+      authorizedClient = managerProvider.provide().authorize(authorizedRequest);
       validateAuthorizedClient(authorizedClient, currentAuthentication);
       authorizedClientService.saveAuthorizedClient(authorizedClient, currentAuthentication);
     }

--- a/support/src/main/java/rocks/metaldetector/support/oauth/OAuth2ClientConfig.java
+++ b/support/src/main/java/rocks/metaldetector/support/oauth/OAuth2ClientConfig.java
@@ -3,6 +3,7 @@ package rocks.metaldetector.support.oauth;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.jdbc.core.JdbcOperations;
+import org.springframework.security.oauth2.client.AuthorizedClientServiceOAuth2AuthorizedClientManager;
 import org.springframework.security.oauth2.client.JdbcOAuth2AuthorizedClientService;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientProvider;
@@ -28,6 +29,17 @@ public class OAuth2ClientConfig {
         .refreshToken()
         .build();
     var manager = new DefaultOAuth2AuthorizedClientManager(clientRegistrationRepository, authorizedClientRepository);
+    manager.setAuthorizedClientProvider(authorizedClientProvider);
+    return manager;
+  }
+
+  @Bean
+  public OAuth2AuthorizedClientManager schedulingAuthorizedClientManager(OAuth2AuthorizedClientService authorizedClientService,
+                                                                         ClientRegistrationRepository clientRegistrationRepository) {
+    OAuth2AuthorizedClientProvider authorizedClientProvider = OAuth2AuthorizedClientProviderBuilder.builder()
+        .clientCredentials()
+        .build();
+    var manager = new AuthorizedClientServiceOAuth2AuthorizedClientManager(clientRegistrationRepository, authorizedClientService);
     manager.setAuthorizedClientProvider(authorizedClientProvider);
     return manager;
   }

--- a/support/src/main/java/rocks/metaldetector/support/oauth/OAuth2ClientManagerProvider.java
+++ b/support/src/main/java/rocks/metaldetector/support/oauth/OAuth2ClientManagerProvider.java
@@ -1,0 +1,23 @@
+package rocks.metaldetector.support.oauth;
+
+import lombok.AllArgsConstructor;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager;
+import org.springframework.stereotype.Component;
+
+import static java.lang.Thread.currentThread;
+import static rocks.metaldetector.support.infrastructure.ApacheHttpClientConfig.SCHEDULED_TASK_NAME_PREFIX;
+
+@Component
+@AllArgsConstructor
+public class OAuth2ClientManagerProvider {
+
+  private final OAuth2AuthorizedClientManager authorizedClientManager;
+  private final OAuth2AuthorizedClientManager schedulingAuthorizedClientManager;
+
+  public OAuth2AuthorizedClientManager provide() {
+    if (currentThread().getName().startsWith(SCHEDULED_TASK_NAME_PREFIX)) {
+      return schedulingAuthorizedClientManager;
+    }
+    return authorizedClientManager;
+  }
+}

--- a/support/src/test/java/rocks/metaldetector/support/oauth/OAuth2ClientManagerProviderTest.java
+++ b/support/src/test/java/rocks/metaldetector/support/oauth/OAuth2ClientManagerProviderTest.java
@@ -1,0 +1,64 @@
+package rocks.metaldetector.support.oauth;
+
+import org.assertj.core.api.WithAssertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager;
+
+import static org.mockito.Mockito.reset;
+import static rocks.metaldetector.support.infrastructure.ApacheHttpClientConfig.SCHEDULED_TASK_NAME_PREFIX;
+
+@ExtendWith(MockitoExtension.class)
+class OAuth2ClientManagerProviderTest implements WithAssertions {
+
+  @Mock
+  private OAuth2AuthorizedClientManager authorizedClientManager;
+
+  @Mock
+  private OAuth2AuthorizedClientManager schedulingAuthorizedClientManager;
+
+  private OAuth2ClientManagerProvider underTest;
+
+  @BeforeEach
+  void setup() {
+    underTest = new OAuth2ClientManagerProvider(authorizedClientManager, schedulingAuthorizedClientManager);
+  }
+
+  @AfterEach
+  void tearDown() {
+    reset(authorizedClientManager, schedulingAuthorizedClientManager);
+  }
+
+  @Test
+  @DisplayName("For a normal thread the default authorizedClientManager is returned")
+  void test_default_manager_returned() {
+    // when
+    var result = underTest.provide();
+
+    // then
+    assertThat(result).isEqualTo(authorizedClientManager);
+  }
+
+  @Test
+  @DisplayName("For a scheduled thread the default authorizedClientManager is returned")
+  void test_scheduling_manager_returned() {
+    // given
+    var scheduler = new ThreadPoolTaskScheduler();
+    scheduler.setThreadNamePrefix(SCHEDULED_TASK_NAME_PREFIX);
+    scheduler.initialize();
+
+    scheduler.execute(() -> {
+      // when
+      var result = underTest.provide();
+
+      // then
+      assertThat(result).isEqualTo(authorizedClientManager);
+    });
+  }
+}

--- a/webapp/src/main/java/rocks/metaldetector/service/notification/messaging/NotificationScheduler.java
+++ b/webapp/src/main/java/rocks/metaldetector/service/notification/messaging/NotificationScheduler.java
@@ -2,6 +2,10 @@ package rocks.metaldetector.service.notification.messaging;
 
 import lombok.AllArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 import rocks.metaldetector.butler.facade.dto.ReleaseDto;
@@ -12,10 +16,13 @@ import java.time.LocalDate;
 import java.util.List;
 
 import static java.time.temporal.ChronoUnit.WEEKS;
+import static org.springframework.security.core.authority.AuthorityUtils.createAuthorityList;
 
 @Component
 @AllArgsConstructor
 public class NotificationScheduler {
+
+  protected static final AnonymousAuthenticationToken PRINCIPAL = new AnonymousAuthenticationToken("key", "anonymous", createAuthorityList("ROLE_ANONYMOUS"));
 
   private final NotificationConfigRepository notificationConfigRepository;
   private final NotificationReleaseCollector notificationReleaseCollector;
@@ -25,25 +32,43 @@ public class NotificationScheduler {
   @Transactional
   public void notifyOnFrequency() {
     var now = LocalDate.now();
-    notificationConfigRepository.findAllActive().stream()
-        .filter(config -> notificationIsDue(config, now))
-        .forEach(config -> frequencyNotification(config, now));
+    setSecurityContext(PRINCIPAL);
+    try {
+      notificationConfigRepository.findAllActive().stream()
+          .filter(config -> notificationIsDue(config, now))
+          .forEach(config -> frequencyNotification(config, now));
+    }
+    finally {
+      setSecurityContext(null);
+    }
   }
 
   @Scheduled(cron = "0 0 7 * * *")
   @Transactional(readOnly = true)
   public void notifyOnReleaseDate() {
-    notificationConfigRepository.findAllActive().stream()
-        .filter(NotificationConfigEntity::getNotificationAtReleaseDate)
-        .forEach(this::releaseDateNotification);
+    setSecurityContext(PRINCIPAL);
+    try {
+      notificationConfigRepository.findAllActive().stream()
+          .filter(NotificationConfigEntity::getNotificationAtReleaseDate)
+          .forEach(this::releaseDateNotification);
+    }
+    finally {
+      setSecurityContext(null);
+    }
   }
 
   @Scheduled(cron = "0 0 7 * * *")
   @Transactional(readOnly = true)
   public void notifyOnAnnouncementDate() {
-    notificationConfigRepository.findAllActive().stream()
-        .filter(NotificationConfigEntity::getNotificationAtAnnouncementDate)
-        .forEach(this::announcementDateNotification);
+    setSecurityContext(PRINCIPAL);
+    try {
+      notificationConfigRepository.findAllActive().stream()
+          .filter(NotificationConfigEntity::getNotificationAtAnnouncementDate)
+          .forEach(this::announcementDateNotification);
+    }
+    finally {
+      setSecurityContext(null);
+    }
   }
 
   private void frequencyNotification(NotificationConfigEntity notificationConfig, LocalDate now) {
@@ -80,5 +105,10 @@ public class NotificationScheduler {
     return notificationConfig.getFrequencyInWeeks() > 0 &&
            (notificationConfig.getLastNotificationDate() == null ||
             WEEKS.between(notificationConfig.getLastNotificationDate(), now) >= notificationConfig.getFrequencyInWeeks());
+  }
+
+  private void setSecurityContext(Authentication authentication) {
+    SecurityContext securityContext = SecurityContextHolder.getContext();
+    securityContext.setAuthentication(authentication);
   }
 }

--- a/webapp/src/test/java/rocks/metaldetector/service/notification/messaging/NotificationSchedulerTest.java
+++ b/webapp/src/test/java/rocks/metaldetector/service/notification/messaging/NotificationSchedulerTest.java
@@ -7,10 +7,14 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
 import rocks.metaldetector.persistence.domain.notification.NotificationConfigEntity;
 import rocks.metaldetector.persistence.domain.notification.NotificationConfigRepository;
 import rocks.metaldetector.persistence.domain.user.AbstractUserEntity;
@@ -33,6 +37,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static rocks.metaldetector.persistence.domain.notification.NotificationChannel.EMAIL;
 import static rocks.metaldetector.persistence.domain.notification.NotificationChannel.TELEGRAM;
+import static rocks.metaldetector.service.notification.messaging.NotificationScheduler.PRINCIPAL;
 
 @ExtendWith(MockitoExtension.class)
 class NotificationSchedulerTest implements WithAssertions {
@@ -216,6 +221,29 @@ class NotificationSchedulerTest implements WithAssertions {
       // then
       verifyNoInteractions(notificationReleaseCollector);
     }
+
+    @Test
+    @DisplayName("current authentication is set to anonymous and then to null again")
+    void test_current_authentication_set_to_anonymous() {
+      // given
+      var securityContextMock = mock(SecurityContext.class);
+
+      try (MockedStatic<SecurityContextHolder> mock = mockStatic(SecurityContextHolder.class)) {
+        //given
+        mock.when(SecurityContextHolder::getContext).thenReturn(securityContextMock);
+
+        //when
+        underTest.notifyOnFrequency();
+
+        //then
+        mock.verify(SecurityContextHolder::getContext, times(2));
+      }
+
+      // then
+      InOrder order = Mockito.inOrder(securityContextMock);
+      order.verify(securityContextMock).setAuthentication(PRINCIPAL);
+      order.verify(securityContextMock).setAuthentication(null);
+    }
   }
 
   @Nested
@@ -334,6 +362,29 @@ class NotificationSchedulerTest implements WithAssertions {
       // then
       verifyNoInteractions(notificationReleaseCollector);
     }
+
+    @Test
+    @DisplayName("current authentication is set to anonymous and then to null again")
+    void test_current_authentication_set_to_anonymous() {
+      // given
+      var securityContextMock = mock(SecurityContext.class);
+
+      try (MockedStatic<SecurityContextHolder> mock = mockStatic(SecurityContextHolder.class)) {
+        //given
+        mock.when(SecurityContextHolder::getContext).thenReturn(securityContextMock);
+
+        //when
+        underTest.notifyOnReleaseDate();
+
+        //then
+        mock.verify(SecurityContextHolder::getContext, times(2));
+      }
+
+      // then
+      InOrder order = Mockito.inOrder(securityContextMock);
+      order.verify(securityContextMock).setAuthentication(PRINCIPAL);
+      order.verify(securityContextMock).setAuthentication(null);
+    }
   }
 
   @Nested
@@ -451,6 +502,29 @@ class NotificationSchedulerTest implements WithAssertions {
 
       // then
       verifyNoInteractions(notificationReleaseCollector);
+    }
+
+    @Test
+    @DisplayName("current authentication is set to anonymous and then to null again")
+    void test_current_authentication_set_to_anonymous() {
+      // given
+      var securityContextMock = mock(SecurityContext.class);
+
+      try (MockedStatic<SecurityContextHolder> mock = mockStatic(SecurityContextHolder.class)) {
+        //given
+        mock.when(SecurityContextHolder::getContext).thenReturn(securityContextMock);
+
+        //when
+        underTest.notifyOnAnnouncementDate();
+
+        //then
+        mock.verify(SecurityContextHolder::getContext, times(2));
+      }
+
+      // then
+      InOrder order = Mockito.inOrder(securityContextMock);
+      order.verify(securityContextMock).setAuthentication(PRINCIPAL);
+      order.verify(securityContextMock).setAuthentication(null);
     }
   }
 }


### PR DESCRIPTION
This turned out to be way more work than I first thought 😓 
Context: since we are using oauth, the notifications are not working anymore. There was an Exception in the ButlerInterceptor because the authentication is null. That is because scheduled tasks are not authenticated. To fix that I now manually set an anonymous user for the scheduled notification tasks. Then everything failed because Spring Security needs a ServletRequest to fetch a new authentication token (for whatever reasons) which also is not available in a task that is scheduled by Spring. To fix that I needed to add the new implementation of the OAuth2AuthorizedClientManager which was designed specifically for this purpose and only has to be used for these scheduled requests. To achieve that, I check if the current thread is scheduled by checking the thread name, which we prefix in the Config of the TaskScheduler. I don't know if there is a more elegant way to find out if a task is scheduled, but this works.