### PR TITLE
Notifications are not read-only anymore

### DIFF
--- a/webapp/src/main/java/rocks/metaldetector/service/notification/messaging/NotificationScheduler.java
+++ b/webapp/src/main/java/rocks/metaldetector/service/notification/messaging/NotificationScheduler.java
@@ -44,7 +44,7 @@ public class NotificationScheduler {
   }
 
   @Scheduled(cron = "0 0 7 * * *")
-  @Transactional(readOnly = true)
+  @Transactional
   public void notifyOnReleaseDate() {
     setSecurityContext(PRINCIPAL);
     try {
@@ -58,7 +58,7 @@ public class NotificationScheduler {
   }
 
   @Scheduled(cron = "0 0 7 * * *")
-  @Transactional(readOnly = true)
+  @Transactional
   public void notifyOnAnnouncementDate() {
     setSecurityContext(PRINCIPAL);
     try {


### PR DESCRIPTION
Using oauth always requires the database, therefore notifications are not read-only anymore.