### PR TITLE
Dependabot activated for npm

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+  - package-ecosystem: "npm"
+    directory: "/webapp/src/main/resources/static/ts"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
Scheduled daily for now, if this is too annoying we can change it too weekly.
I'll merge this after https://github.com/MetalDetectorRocks/metal-detector-main/pull/583 as there are some dependency updates in it.