### PR TITLE
Better config for github workflow to build docker image

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -26,5 +26,5 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
-      - name: Execute gradle task 'bootJar' and 'publish'
-        run: ./gradlew clean bootJar publish --no-daemon --info --stacktrace
+      - name: Execute gradle task 'build' and 'publish'
+        run: ./gradlew clean build publish --no-daemon --info --stacktrace


### PR DESCRIPTION
Unlike in butler and auth we don't even run tests here when pushing to master, so I just activated it in the docker task. See [here](https://github.com/MetalDetectorRocks/metal-release-butler/pull/265) or [here](https://github.com/MetalDetectorRocks/metal-detector-auth/pull/51) for motivation.