### PR TITLE
Configure shutdown lifecycle

### DIFF
--- a/support/src/main/java/rocks/metaldetector/support/infrastructure/ApacheHttpClientConfig.java
+++ b/support/src/main/java/rocks/metaldetector/support/infrastructure/ApacheHttpClientConfig.java
@@ -91,14 +91,6 @@ public class ApacheHttpClientConfig {
   }
 
   @Bean
-  public TaskScheduler taskScheduler() {
-    ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
-    scheduler.setThreadNamePrefix(SCHEDULED_TASK_NAME_PREFIX);
-    scheduler.setPoolSize(5);
-    return scheduler;
-  }
-
-  @Bean
   public CloseableHttpClient httpClient() {
     RequestConfig requestConfig = RequestConfig.custom()
             .setConnectTimeout((int) Duration.ofSeconds(20).toMillis()) // the time for waiting until a connection is established

--- a/webapp/src/main/resources/application.yml
+++ b/webapp/src/main/resources/application.yml
@@ -4,6 +4,17 @@ application:
 spring:
   application:
     name: Metal Detector
+  lifecycle:
+    timeout-per-shutdown-phase: 60s
+  task:
+    scheduling:
+      shutdown:
+        await-termination: true
+        await-termination-period: PT1M
+    execution:
+      shutdown:
+        await-termination: true
+        await-termination-period: PT1M
   datasource:
     username: ${DATASOURCE_USERNAME}
     password: ${DATASOURCE_PASSWORD}


### PR DESCRIPTION
We ran into an interesting problem at work so I thought I'd configure it here too: on (graceful) shutdown, spring by default does not pay attention to any running async or scheduled tasks. These are just killed/ignored. So if you deploy a new version and some task is still running, it fails. With these timeouts configured, this does not happen. I deleted the taskScheduler-Bean because now spring takes care about creating a scheduler. We did not use this bean in any other place and the default configuration is fine for our use cases in my opinion. If you think we do need our own bean there I can also configure the timeouts there. Then the application.yml config for scheduled tasks is ignored and we have to configure it on our own scheduler.