### PR TITLE
add optional login mock mode for tests localhost fe <-> preview be

### DIFF
--- a/webapp/src/main/java/rocks/metaldetector/service/auth/RefreshTokenService.java
+++ b/webapp/src/main/java/rocks/metaldetector/service/auth/RefreshTokenService.java
@@ -75,7 +75,7 @@ public class RefreshTokenService {
     return jwtsSupport.generateToken(tokenEntityId, duration);
   }
 
-  private String createAccessToken(String publicUserId) {
+  public String createAccessToken(String publicUserId) {
     Duration duration = Duration.ofMinutes(securityProperties.getAccessTokenExpirationInMin());
     return jwtsSupport.generateToken(publicUserId, duration);
   }

--- a/webapp/src/main/java/rocks/metaldetector/web/controller/rest/auth/AuthenticationRestController.java
+++ b/webapp/src/main/java/rocks/metaldetector/web/controller/rest/auth/AuthenticationRestController.java
@@ -3,63 +3,31 @@ package rocks.metaldetector.web.controller.rest.auth;
 import jakarta.validation.Valid;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.CookieValue;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.RequestBody;
 import rocks.metaldetector.service.auth.ResetPasswordService;
-import rocks.metaldetector.service.auth.RefreshTokenData;
-import rocks.metaldetector.service.auth.RefreshTokenService;
 import rocks.metaldetector.service.user.UserService;
 import rocks.metaldetector.web.api.auth.InitResetPasswordRequest;
-import rocks.metaldetector.web.api.auth.LoginResponse;
-import rocks.metaldetector.web.api.auth.AuthenticationResponse;
 import rocks.metaldetector.web.api.auth.RegisterUserRequest;
 import rocks.metaldetector.web.api.auth.RegistrationVerificationRequest;
 import rocks.metaldetector.web.api.auth.RegistrationVerificationResponse;
 import rocks.metaldetector.web.api.auth.ResetPasswordRequest;
 
-import static org.springframework.http.HttpHeaders.SET_COOKIE;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
-import static rocks.metaldetector.service.auth.RefreshTokenService.REFRESH_TOKEN_COOKIE_NAME;
-import static rocks.metaldetector.support.Endpoints.Rest.AUTHENTICATION;
-import static rocks.metaldetector.support.Endpoints.Rest.REFRESH_ACCESS_TOKEN;
 import static rocks.metaldetector.support.Endpoints.Rest.REGISTER;
 import static rocks.metaldetector.support.Endpoints.Rest.REGISTRATION_VERIFICATION;
 import static rocks.metaldetector.support.Endpoints.Rest.REQUEST_PASSWORD_RESET;
 import static rocks.metaldetector.support.Endpoints.Rest.RESET_PASSWORD;
 
+@Slf4j
 @RestController
 @AllArgsConstructor
-@Slf4j
 public class AuthenticationRestController {
 
-  private final RefreshTokenService refreshTokenService;
   private final UserService userService;
   private final ResetPasswordService resetPasswordService;
-
-  @GetMapping(path = AUTHENTICATION, produces = APPLICATION_JSON_VALUE)
-  public ResponseEntity<AuthenticationResponse> authenticated(@CookieValue(name = REFRESH_TOKEN_COOKIE_NAME, required = false) String refreshToken) {
-    return ResponseEntity.ok(
-        AuthenticationResponse.builder()
-            .authenticated(refreshTokenService.isValid(refreshToken))
-            .build()
-    );
-  }
-
-  @GetMapping(value = REFRESH_ACCESS_TOKEN, produces = APPLICATION_JSON_VALUE)
-  public ResponseEntity<LoginResponse> refreshAccessToken(@CookieValue(name = REFRESH_TOKEN_COOKIE_NAME) String refreshToken) {
-    RefreshTokenData refreshTokenData = refreshTokenService.refreshTokens(refreshToken);
-    HttpHeaders httpHeaders = new HttpHeaders();
-    httpHeaders.add(SET_COOKIE, refreshTokenData.refreshToken().toString());
-
-    return ResponseEntity.ok()
-        .headers(httpHeaders)
-        .body(refreshTokenData.asLoginResponse());
-  }
 
   @PostMapping(value = REGISTER, consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
   public ResponseEntity<Void> registerUser(@Valid @RequestBody RegisterUserRequest registerUserRequest) {

--- a/webapp/src/main/java/rocks/metaldetector/web/controller/rest/auth/MockRefreshTokenRestController.java
+++ b/webapp/src/main/java/rocks/metaldetector/web/controller/rest/auth/MockRefreshTokenRestController.java
@@ -1,0 +1,49 @@
+package rocks.metaldetector.web.controller.rest.auth;
+
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import rocks.metaldetector.persistence.domain.user.UserEntity;
+import rocks.metaldetector.persistence.domain.user.UserRepository;
+import rocks.metaldetector.service.auth.RefreshTokenData;
+import rocks.metaldetector.service.auth.RefreshTokenService;
+import rocks.metaldetector.web.api.auth.AuthenticationResponse;
+import rocks.metaldetector.web.api.auth.LoginResponse;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static rocks.metaldetector.support.Endpoints.Rest.AUTHENTICATION;
+import static rocks.metaldetector.support.Endpoints.Rest.REFRESH_ACCESS_TOKEN;
+
+@Slf4j
+@RestController
+@AllArgsConstructor
+@ConditionalOnProperty(
+    name = "security.mock-mode",
+    havingValue = "true"
+)
+public class MockRefreshTokenRestController {
+
+  private final UserRepository userRepository;
+  private final RefreshTokenService refreshTokenService;
+
+  @GetMapping(path = AUTHENTICATION, produces = APPLICATION_JSON_VALUE)
+  public ResponseEntity<AuthenticationResponse> authenticated() {
+    return ResponseEntity.ok(new AuthenticationResponse(true));
+  }
+
+  @GetMapping(value = REFRESH_ACCESS_TOKEN, produces = APPLICATION_JSON_VALUE)
+  public ResponseEntity<LoginResponse> refreshAccessToken() {
+    UserEntity administrator = userRepository.getByUsername("Administrator");
+    String accessToken = refreshTokenService.createAccessToken(administrator.getPublicId());
+    RefreshTokenData refreshTokenData = new RefreshTokenData(
+        administrator.getUsername(),
+        administrator.getUserRoleNames(),
+        accessToken,
+        null
+    );
+    return ResponseEntity.ok().body(refreshTokenData.asLoginResponse());
+  }
+}

--- a/webapp/src/main/java/rocks/metaldetector/web/controller/rest/auth/RefreshTokenRestController.java
+++ b/webapp/src/main/java/rocks/metaldetector/web/controller/rest/auth/RefreshTokenRestController.java
@@ -1,0 +1,52 @@
+package rocks.metaldetector.web.controller.rest.auth;
+
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import rocks.metaldetector.service.auth.RefreshTokenData;
+import rocks.metaldetector.service.auth.RefreshTokenService;
+import rocks.metaldetector.web.api.auth.AuthenticationResponse;
+import rocks.metaldetector.web.api.auth.LoginResponse;
+
+import static org.springframework.http.HttpHeaders.SET_COOKIE;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static rocks.metaldetector.service.auth.RefreshTokenService.REFRESH_TOKEN_COOKIE_NAME;
+import static rocks.metaldetector.support.Endpoints.Rest.AUTHENTICATION;
+import static rocks.metaldetector.support.Endpoints.Rest.REFRESH_ACCESS_TOKEN;
+
+@Slf4j
+@RestController
+@AllArgsConstructor
+@ConditionalOnProperty(
+    name = "security.mock-mode",
+    havingValue = "false"
+)
+public class RefreshTokenRestController {
+
+  private final RefreshTokenService refreshTokenService;
+
+  @GetMapping(path = AUTHENTICATION, produces = APPLICATION_JSON_VALUE)
+  public ResponseEntity<AuthenticationResponse> authenticated(@CookieValue(name = REFRESH_TOKEN_COOKIE_NAME, required = false) String refreshToken) {
+    return ResponseEntity.ok(
+        AuthenticationResponse.builder()
+            .authenticated(refreshTokenService.isValid(refreshToken))
+            .build()
+    );
+  }
+
+  @GetMapping(value = REFRESH_ACCESS_TOKEN, produces = APPLICATION_JSON_VALUE)
+  public ResponseEntity<LoginResponse> refreshAccessToken(@CookieValue(name = REFRESH_TOKEN_COOKIE_NAME) String refreshToken) {
+    RefreshTokenData refreshTokenData = refreshTokenService.refreshTokens(refreshToken);
+    HttpHeaders httpHeaders = new HttpHeaders();
+    httpHeaders.add(SET_COOKIE, refreshTokenData.refreshToken().toString());
+
+    return ResponseEntity.ok()
+        .headers(httpHeaders)
+        .body(refreshTokenData.asLoginResponse());
+  }
+}

--- a/webapp/src/main/resources/application-preview.yml
+++ b/webapp/src/main/resources/application-preview.yml
@@ -50,6 +50,7 @@ management:
 
 security:
   secure-cookie: true
+  mock-mode: true
 
 metal-release-butler:
   host: http://butler-app:8080

--- a/webapp/src/main/resources/application-prod.yml
+++ b/webapp/src/main/resources/application-prod.yml
@@ -53,6 +53,7 @@ management:
 
 security:
   secure-cookie: true
+  mock-mode: false
 
 metal-release-butler:
   host: http://butler-app:8080

--- a/webapp/src/main/resources/application.yml
+++ b/webapp/src/main/resources/application.yml
@@ -113,6 +113,7 @@ security:
   access-token-expiration-in-min: 15
   refresh-token-expiration-in-min: 43800 # 30 days
   secure-cookie: false
+  mock-mode: false
 
 server:
   port: 8080

--- a/webapp/src/test/java/rocks/metaldetector/web/controller/rest/auth/AuthenticationRestControllerIntegrationTest.java
+++ b/webapp/src/test/java/rocks/metaldetector/web/controller/rest/auth/AuthenticationRestControllerIntegrationTest.java
@@ -1,7 +1,6 @@
-package rocks.metaldetector.web.controller.rest;
+package rocks.metaldetector.web.controller.rest.auth;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -9,12 +8,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.http.ResponseCookie;
 import org.springframework.security.test.context.support.WithAnonymousUser;
 import org.springframework.test.web.servlet.MockMvc;
 import rocks.metaldetector.service.auth.ResetPasswordService;
-import rocks.metaldetector.service.auth.RefreshTokenService;
-import rocks.metaldetector.service.auth.RefreshTokenData;
 import rocks.metaldetector.service.user.UserService;
 import rocks.metaldetector.testutil.BaseSpringBootTest;
 import rocks.metaldetector.web.api.auth.InitResetPasswordRequest;
@@ -22,17 +18,9 @@ import rocks.metaldetector.web.api.auth.RegisterUserRequest;
 import rocks.metaldetector.web.api.auth.RegistrationVerificationRequest;
 import rocks.metaldetector.web.api.auth.ResetPasswordRequest;
 
-import java.util.List;
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doReturn;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static rocks.metaldetector.persistence.domain.user.UserRole.ROLE_USER;
-import static rocks.metaldetector.support.Endpoints.Rest.AUTHENTICATION;
-import static rocks.metaldetector.support.Endpoints.Rest.REFRESH_ACCESS_TOKEN;
 import static rocks.metaldetector.support.Endpoints.Rest.REGISTER;
 import static rocks.metaldetector.support.Endpoints.Rest.REGISTRATION_VERIFICATION;
 import static rocks.metaldetector.support.Endpoints.Rest.REQUEST_PASSWORD_RESET;
@@ -49,9 +37,6 @@ class AuthenticationRestControllerIntegrationTest extends BaseSpringBootTest {
   private ObjectMapper objectMapper;
 
   @MockBean
-  private RefreshTokenService refreshTokenService;
-
-  @MockBean
   @SuppressWarnings("unused")
   private UserService userService;
 
@@ -61,43 +46,6 @@ class AuthenticationRestControllerIntegrationTest extends BaseSpringBootTest {
 
   @Nested
   class AnonymousUserTest {
-
-    @Test
-    @DisplayName("Anonymous user is allowed to GET on endpoint " + AUTHENTICATION + "'")
-    @WithAnonymousUser
-    void anonymous_user_is_allowed_to_get_on_endpoint_authentication() throws Exception {
-      mockMvc.perform(get(AUTHENTICATION)
-              .accept(APPLICATION_JSON)
-          )
-          .andExpect(status().isOk());
-    }
-
-    @Test
-    @DisplayName("Anonymous user with refresh token in cookie is allowed to GET on endpoint " + REFRESH_ACCESS_TOKEN + "'")
-    @WithAnonymousUser
-    void anonymous_user_with_cookie_is_allowed_to_refresh_tokens() throws Exception {
-      var refreshTokenData = new RefreshTokenData(
-          "dummy",
-          List.of(ROLE_USER.getDisplayName()),
-          "access-token",
-          ResponseCookie.from("refresh_token", "refresh-token").build()
-      );
-      doReturn(refreshTokenData).when(refreshTokenService).refreshTokens(any());
-
-      mockMvc.perform(get(REFRESH_ACCESS_TOKEN)
-              .cookie(new Cookie("refresh_token", "eyFoo"))
-              .accept(APPLICATION_JSON))
-          .andExpect(status().isOk());
-    }
-
-    @Test
-    @DisplayName("Anonymous user needs refresh token in cookie to GET on endpoint " + REFRESH_ACCESS_TOKEN + "'")
-    @WithAnonymousUser
-    void anonymous_user_needs_refresh_token_in_cookie_to_refresh_tokens() throws Exception {
-      mockMvc.perform(get(REFRESH_ACCESS_TOKEN)
-              .accept(APPLICATION_JSON))
-          .andExpect(status().isUnauthorized());
-    }
 
     @Test
     @DisplayName("Anonymous user is allowed to POST on endpoint " + REGISTER + "'")

--- a/webapp/src/test/java/rocks/metaldetector/web/controller/rest/auth/AuthenticationRestControllerTest.java
+++ b/webapp/src/test/java/rocks/metaldetector/web/controller/rest/auth/AuthenticationRestControllerTest.java
@@ -1,8 +1,6 @@
-package rocks.metaldetector.web.controller.rest;
+package rocks.metaldetector.web.controller.rest.auth;
 
-import io.restassured.http.Header;
 import io.restassured.module.mockmvc.RestAssuredMockMvc;
-import io.restassured.module.mockmvc.response.ValidatableMockMvcResponse;
 import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -13,37 +11,21 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.http.ResponseCookie;
 import rocks.metaldetector.service.auth.ResetPasswordService;
-import rocks.metaldetector.service.auth.RefreshTokenData;
 import rocks.metaldetector.service.exceptions.RestExceptionsHandler;
-import rocks.metaldetector.service.auth.RefreshTokenService;
 import rocks.metaldetector.service.user.UserService;
 import rocks.metaldetector.web.RestAssuredMockMvcUtils;
-import rocks.metaldetector.web.api.auth.AuthenticationResponse;
-import rocks.metaldetector.web.api.auth.LoginResponse;
 import rocks.metaldetector.web.api.auth.InitResetPasswordRequest;
 import rocks.metaldetector.web.api.auth.RegisterUserRequest;
 import rocks.metaldetector.web.api.auth.RegistrationVerificationRequest;
 import rocks.metaldetector.web.api.auth.RegistrationVerificationResponse;
 import rocks.metaldetector.web.api.auth.ResetPasswordRequest;
-import rocks.metaldetector.web.controller.rest.auth.AuthenticationRestController;
-
-import java.util.List;
-import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.springframework.http.HttpHeaders.SET_COOKIE;
 import static org.springframework.http.HttpStatus.OK;
-import static org.springframework.http.HttpStatus.UNAUTHORIZED;
-import static rocks.metaldetector.persistence.domain.user.UserRole.ROLE_USER;
-import static rocks.metaldetector.service.auth.RefreshTokenService.REFRESH_TOKEN_COOKIE_NAME;
-import static rocks.metaldetector.support.Endpoints.Rest.AUTHENTICATION;
-import static rocks.metaldetector.support.Endpoints.Rest.REFRESH_ACCESS_TOKEN;
 import static rocks.metaldetector.support.Endpoints.Rest.REGISTER;
 import static rocks.metaldetector.support.Endpoints.Rest.REGISTRATION_VERIFICATION;
 import static rocks.metaldetector.support.Endpoints.Rest.REQUEST_PASSWORD_RESET;
@@ -51,9 +33,6 @@ import static rocks.metaldetector.support.Endpoints.Rest.RESET_PASSWORD;
 
 @ExtendWith(MockitoExtension.class)
 class AuthenticationRestControllerTest implements WithAssertions {
-
-  @Mock
-  private RefreshTokenService refreshTokenService;
 
   @Mock
   private UserService userService;
@@ -68,151 +47,7 @@ class AuthenticationRestControllerTest implements WithAssertions {
 
   @AfterEach
   void tearDown() {
-    reset(refreshTokenService, userService, resetPasswordService);
-  }
-
-  @Nested
-  class AuthenticatedTests {
-
-    @BeforeEach
-    void setup() {
-      restAssuredUtils = new RestAssuredMockMvcUtils(AUTHENTICATION);
-      RestAssuredMockMvc.standaloneSetup(underTest, RestExceptionsHandler.class);
-    }
-
-    @Test
-    @DisplayName("should return false if user is not authenticated")
-    void should_return_false_if_user_is_not_authenticated() {
-      // given
-      doReturn(false).when(refreshTokenService).isValid(any());
-
-      // when
-      ValidatableMockMvcResponse response = restAssuredUtils.doGet();
-
-      // then
-      var authenticationResponse = response.extract().as(AuthenticationResponse.class);
-      response.status(OK);
-      assertThat(authenticationResponse.isAuthenticated()).isFalse();
-    }
-
-    @Test
-    @DisplayName("should return true if user is authenticated")
-    void should_return_true_if_user_is_authenticated() {
-      // given
-      doReturn(true).when(refreshTokenService).isValid(any());
-
-      // when
-      ValidatableMockMvcResponse response = restAssuredUtils.doGet();
-
-      // then
-      var authenticationResponse = response.extract().as(AuthenticationResponse.class);
-      response.status(OK);
-      assertThat(authenticationResponse.isAuthenticated()).isTrue();
-    }
-
-    @Test
-    @DisplayName("should pass token from cookie")
-    void should_pass_token_from_cookie() {
-      // given
-      String token = "eyFoobar";
-
-      // when
-      restAssuredUtils.doGetWithCookies(Map.of(REFRESH_TOKEN_COOKIE_NAME, token));
-
-      // then
-      verify(refreshTokenService).isValid(token);
-    }
-  }
-
-  @Nested
-  class RefreshAccessTokenTests {
-
-    @BeforeEach
-    void setup() {
-      restAssuredUtils = new RestAssuredMockMvcUtils(REFRESH_ACCESS_TOKEN);
-      RestAssuredMockMvc.standaloneSetup(underTest, RestExceptionsHandler.class);
-    }
-
-    @Test
-    @DisplayName("should return 401 if refresh token cookie is not present")
-    void should_return_401_if_refresh_token_cookie_is_not_present() {
-      // when
-      var response = restAssuredUtils.doGetWithCookies(Map.of());
-
-      // then
-      response.status(UNAUTHORIZED);
-    }
-
-    @Test
-    @DisplayName("should return ok")
-    void should_return_ok() {
-      // given
-      var refreshTokenData = new RefreshTokenData(
-          "dummy",
-          List.of(ROLE_USER.getDisplayName()),
-          "eyAccessToken",
-          ResponseCookie.from("foo", "bar").build()
-      );
-      doReturn(refreshTokenData).when(refreshTokenService).refreshTokens(any());
-
-      // when
-      var response = restAssuredUtils.doGetWithCookies(Map.of("refresh_token", "eyFoo"));
-
-      // then
-      response.status(OK);
-    }
-
-    @Test
-    @DisplayName("should pass refresh token from cookie to refresh token service")
-    void should_pass_refresh_token_from_cookie_to_refresh_token_service() {
-      // given
-      var refreshToken = "eyRefreshToken";
-
-      // when
-      restAssuredUtils.doGetWithCookies(Map.of("refresh_token", refreshToken));
-
-      // then
-      verify(refreshTokenService).refreshTokens(refreshToken);
-    }
-
-    @Test
-    @DisplayName("should return login response in body")
-    void should_return_login_response() {
-      // given
-      var refreshTokenData = new RefreshTokenData(
-          "dummy",
-          List.of(ROLE_USER.getDisplayName()),
-          "eyAccessToken",
-          ResponseCookie.from("foo", "bar").build()
-      );
-      doReturn(refreshTokenData).when(refreshTokenService).refreshTokens(any());
-
-      // when
-      var response = restAssuredUtils.doGetWithCookies(Map.of("refresh_token", "eyFoo"));
-
-      // then
-      var extractedResponse = response.extract().as(LoginResponse.class);
-      assertThat(extractedResponse).isEqualTo(new LoginResponse("dummy", List.of("User"), "eyAccessToken"));
-    }
-
-    @Test
-    @DisplayName("should return response with cookie header")
-    void should_return_response_with_cookie_header() {
-      // given
-      var refreshTokenData = new RefreshTokenData(
-          "dummy",
-          List.of(ROLE_USER.getDisplayName()),
-          "eyAccessToken",
-          ResponseCookie.from("refresh_token", "eyRefreshToken").build()
-      );
-      doReturn(refreshTokenData).when(refreshTokenService).refreshTokens(any());
-
-      // when
-      var headers = restAssuredUtils.doGetWithCookiesReturningHeaders(Map.of("refresh_token", "eyFoo"));
-
-      // then
-      assertThat(headers).contains(new Header(SET_COOKIE, "refresh_token=eyRefreshToken"));
-    }
+    reset(userService, resetPasswordService);
   }
 
   @Nested

--- a/webapp/src/test/java/rocks/metaldetector/web/controller/rest/auth/MockRefreshTokenRestControllerTest.java
+++ b/webapp/src/test/java/rocks/metaldetector/web/controller/rest/auth/MockRefreshTokenRestControllerTest.java
@@ -1,0 +1,146 @@
+package rocks.metaldetector.web.controller.rest.auth;
+
+import io.restassured.module.mockmvc.RestAssuredMockMvc;
+import io.restassured.module.mockmvc.response.ValidatableMockMvcResponse;
+import org.assertj.core.api.WithAssertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import rocks.metaldetector.persistence.domain.user.UserEntity;
+import rocks.metaldetector.persistence.domain.user.UserRepository;
+import rocks.metaldetector.service.auth.RefreshTokenService;
+import rocks.metaldetector.service.exceptions.RestExceptionsHandler;
+import rocks.metaldetector.web.RestAssuredMockMvcUtils;
+import rocks.metaldetector.web.api.auth.AuthenticationResponse;
+import rocks.metaldetector.web.api.auth.LoginResponse;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.http.HttpStatus.OK;
+import static rocks.metaldetector.persistence.domain.user.UserRole.ROLE_USER;
+import static rocks.metaldetector.support.Endpoints.Rest.AUTHENTICATION;
+import static rocks.metaldetector.support.Endpoints.Rest.REFRESH_ACCESS_TOKEN;
+
+@ExtendWith(MockitoExtension.class)
+public class MockRefreshTokenRestControllerTest implements WithAssertions {
+
+  @Mock
+  private RefreshTokenService refreshTokenService;
+
+  @Mock
+  private UserRepository userRepository;
+
+  @InjectMocks
+  private MockRefreshTokenRestController underTest;
+
+  private RestAssuredMockMvcUtils restAssuredUtils;
+
+  @AfterEach
+  void tearDown() {
+    reset(refreshTokenService, userRepository);
+  }
+
+  @Nested
+  class AuthenticatedTests {
+
+    @BeforeEach
+    void setup() {
+      restAssuredUtils = new RestAssuredMockMvcUtils(AUTHENTICATION);
+      RestAssuredMockMvc.standaloneSetup(underTest, RestExceptionsHandler.class);
+    }
+
+    @Test
+    @DisplayName("should return true")
+    void should_return_false_if_user_is_not_authenticated() {
+      // given
+      doReturn(false).when(refreshTokenService).isValid(any());
+
+      // when
+      ValidatableMockMvcResponse response = restAssuredUtils.doGet();
+
+      // then
+      var authenticationResponse = response.extract().as(AuthenticationResponse.class);
+      response.status(OK);
+      assertThat(authenticationResponse.isAuthenticated()).isTrue();
+    }
+  }
+
+  @Nested
+  class RefreshAccessTokenTests {
+
+    @BeforeEach
+    void setup() {
+      restAssuredUtils = new RestAssuredMockMvcUtils(REFRESH_ACCESS_TOKEN);
+      RestAssuredMockMvc.standaloneSetup(underTest, RestExceptionsHandler.class);
+    }
+
+    @Test
+    @DisplayName("should fetch Administrator user")
+    void should_fetch_administrator_user() {
+      // when
+      restAssuredUtils.doGet();
+
+      // then
+      verify(userRepository).getByUsername("Administrator");
+    }
+
+    @Test
+    @DisplayName("should create new access token with administrator's public id")
+    void should_create_new_access_token_with_administrators_public_id() {
+      // given
+      UserEntity user = mock(UserEntity.class);
+      when(user.getPublicId()).thenReturn("test-public-id");
+      when(userRepository.getByUsername(any())).thenReturn(user);
+
+      // when
+      restAssuredUtils.doGet();
+
+      // then
+      verify(refreshTokenService).createAccessToken("test-public-id");
+    }
+
+    @Test
+    @DisplayName("should return ok")
+    void should_return_ok() {
+      // given
+      when(userRepository.getByUsername(any())).thenReturn(mock(UserEntity.class));
+
+      // when
+      var response = restAssuredUtils.doGet();
+
+      // then
+      response.status(OK);
+    }
+
+    @Test
+    @DisplayName("should return login response in body")
+    void should_return_login_response() {
+      // given
+      UserEntity user = mock(UserEntity.class);
+      when(user.getUsername()).thenReturn("dummy");
+      when(user.getUserRoleNames()).thenReturn(List.of(ROLE_USER.getDisplayName()));
+      when(user.getPublicId()).thenReturn("test-public-id");
+      when(userRepository.getByUsername(any())).thenReturn(user);
+      when(refreshTokenService.createAccessToken(any())).thenReturn("eyAccessToken");
+
+      // when
+      var response = restAssuredUtils.doGet();
+
+      // then
+      var extractedResponse = response.extract().as(LoginResponse.class);
+      assertThat(extractedResponse).isEqualTo(new LoginResponse("dummy", List.of("User"), "eyAccessToken"));
+    }
+  }
+}

--- a/webapp/src/test/java/rocks/metaldetector/web/controller/rest/auth/RefreshTokenRestControllerIntegrationTest.java
+++ b/webapp/src/test/java/rocks/metaldetector/web/controller/rest/auth/RefreshTokenRestControllerIntegrationTest.java
@@ -1,0 +1,79 @@
+package rocks.metaldetector.web.controller.rest.auth;
+
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.ResponseCookie;
+import org.springframework.security.test.context.support.WithAnonymousUser;
+import org.springframework.test.web.servlet.MockMvc;
+import rocks.metaldetector.service.auth.RefreshTokenData;
+import rocks.metaldetector.service.auth.RefreshTokenService;
+import rocks.metaldetector.testutil.BaseSpringBootTest;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static rocks.metaldetector.persistence.domain.user.UserRole.ROLE_USER;
+import static rocks.metaldetector.support.Endpoints.Rest.AUTHENTICATION;
+import static rocks.metaldetector.support.Endpoints.Rest.REFRESH_ACCESS_TOKEN;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class RefreshTokenRestControllerIntegrationTest extends BaseSpringBootTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @MockBean
+  private RefreshTokenService refreshTokenService;
+
+  @Nested
+  class AnonymousUserTest {
+
+    @Test
+    @DisplayName("Anonymous user is allowed to GET on endpoint " + AUTHENTICATION + "'")
+    @WithAnonymousUser
+    void anonymous_user_is_allowed_to_get_on_endpoint_authentication() throws Exception {
+      mockMvc.perform(get(AUTHENTICATION)
+              .accept(APPLICATION_JSON)
+          )
+          .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("Anonymous user with refresh token in cookie is allowed to GET on endpoint " + REFRESH_ACCESS_TOKEN + "'")
+    @WithAnonymousUser
+    void anonymous_user_with_cookie_is_allowed_to_refresh_tokens() throws Exception {
+      var refreshTokenData = new RefreshTokenData(
+          "dummy",
+          List.of(ROLE_USER.getDisplayName()),
+          "access-token",
+          ResponseCookie.from("refresh_token", "refresh-token").build()
+      );
+      doReturn(refreshTokenData).when(refreshTokenService).refreshTokens(any());
+
+      mockMvc.perform(get(REFRESH_ACCESS_TOKEN)
+              .cookie(new Cookie("refresh_token", "eyFoo"))
+              .accept(APPLICATION_JSON))
+          .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("Anonymous user needs refresh token in cookie to GET on endpoint " + REFRESH_ACCESS_TOKEN + "'")
+    @WithAnonymousUser
+    void anonymous_user_needs_refresh_token_in_cookie_to_refresh_tokens() throws Exception {
+      mockMvc.perform(get(REFRESH_ACCESS_TOKEN)
+              .accept(APPLICATION_JSON))
+          .andExpect(status().isUnauthorized());
+    }
+  }
+}

--- a/webapp/src/test/java/rocks/metaldetector/web/controller/rest/auth/RefreshTokenRestControllerTest.java
+++ b/webapp/src/test/java/rocks/metaldetector/web/controller/rest/auth/RefreshTokenRestControllerTest.java
@@ -1,0 +1,198 @@
+package rocks.metaldetector.web.controller.rest.auth;
+
+import io.restassured.http.Header;
+import io.restassured.module.mockmvc.RestAssuredMockMvc;
+import io.restassured.module.mockmvc.response.ValidatableMockMvcResponse;
+import org.assertj.core.api.WithAssertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseCookie;
+import rocks.metaldetector.service.auth.RefreshTokenData;
+import rocks.metaldetector.service.auth.RefreshTokenService;
+import rocks.metaldetector.service.exceptions.RestExceptionsHandler;
+import rocks.metaldetector.web.RestAssuredMockMvcUtils;
+import rocks.metaldetector.web.api.auth.AuthenticationResponse;
+import rocks.metaldetector.web.api.auth.LoginResponse;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.springframework.http.HttpHeaders.SET_COOKIE;
+import static org.springframework.http.HttpStatus.OK;
+import static org.springframework.http.HttpStatus.UNAUTHORIZED;
+import static rocks.metaldetector.persistence.domain.user.UserRole.ROLE_USER;
+import static rocks.metaldetector.service.auth.RefreshTokenService.REFRESH_TOKEN_COOKIE_NAME;
+import static rocks.metaldetector.support.Endpoints.Rest.AUTHENTICATION;
+import static rocks.metaldetector.support.Endpoints.Rest.REFRESH_ACCESS_TOKEN;
+
+@ExtendWith(MockitoExtension.class)
+public class RefreshTokenRestControllerTest  implements WithAssertions {
+
+  @Mock
+  private RefreshTokenService refreshTokenService;
+
+  @InjectMocks
+  private RefreshTokenRestController underTest;
+
+  private RestAssuredMockMvcUtils restAssuredUtils;
+
+  @AfterEach
+  void tearDown() {
+    reset(refreshTokenService);
+  }
+
+  @Nested
+  class AuthenticatedTests {
+
+    @BeforeEach
+    void setup() {
+      restAssuredUtils = new RestAssuredMockMvcUtils(AUTHENTICATION);
+      RestAssuredMockMvc.standaloneSetup(underTest, RestExceptionsHandler.class);
+    }
+
+    @Test
+    @DisplayName("should return false if user is not authenticated")
+    void should_return_false_if_user_is_not_authenticated() {
+      // given
+      doReturn(false).when(refreshTokenService).isValid(any());
+
+      // when
+      ValidatableMockMvcResponse response = restAssuredUtils.doGet();
+
+      // then
+      var authenticationResponse = response.extract().as(AuthenticationResponse.class);
+      response.status(OK);
+      assertThat(authenticationResponse.isAuthenticated()).isFalse();
+    }
+
+    @Test
+    @DisplayName("should return true if user is authenticated")
+    void should_return_true_if_user_is_authenticated() {
+      // given
+      doReturn(true).when(refreshTokenService).isValid(any());
+
+      // when
+      ValidatableMockMvcResponse response = restAssuredUtils.doGet();
+
+      // then
+      var authenticationResponse = response.extract().as(AuthenticationResponse.class);
+      response.status(OK);
+      assertThat(authenticationResponse.isAuthenticated()).isTrue();
+    }
+
+    @Test
+    @DisplayName("should pass token from cookie")
+    void should_pass_token_from_cookie() {
+      // given
+      String token = "eyFoobar";
+
+      // when
+      restAssuredUtils.doGetWithCookies(Map.of(REFRESH_TOKEN_COOKIE_NAME, token));
+
+      // then
+      verify(refreshTokenService).isValid(token);
+    }
+  }
+
+  @Nested
+  class RefreshAccessTokenTests {
+
+    @BeforeEach
+    void setup() {
+      restAssuredUtils = new RestAssuredMockMvcUtils(REFRESH_ACCESS_TOKEN);
+      RestAssuredMockMvc.standaloneSetup(underTest, RestExceptionsHandler.class);
+    }
+
+    @Test
+    @DisplayName("should return 401 if refresh token cookie is not present")
+    void should_return_401_if_refresh_token_cookie_is_not_present() {
+      // when
+      var response = restAssuredUtils.doGetWithCookies(Map.of());
+
+      // then
+      response.status(UNAUTHORIZED);
+    }
+
+    @Test
+    @DisplayName("should return ok")
+    void should_return_ok() {
+      // given
+      var refreshTokenData = new RefreshTokenData(
+          "dummy",
+          List.of(ROLE_USER.getDisplayName()),
+          "eyAccessToken",
+          ResponseCookie.from("foo", "bar").build()
+      );
+      doReturn(refreshTokenData).when(refreshTokenService).refreshTokens(any());
+
+      // when
+      var response = restAssuredUtils.doGetWithCookies(Map.of("refresh_token", "eyFoo"));
+
+      // then
+      response.status(OK);
+    }
+
+    @Test
+    @DisplayName("should pass refresh token from cookie to refresh token service")
+    void should_pass_refresh_token_from_cookie_to_refresh_token_service() {
+      // given
+      var refreshToken = "eyRefreshToken";
+
+      // when
+      restAssuredUtils.doGetWithCookies(Map.of("refresh_token", refreshToken));
+
+      // then
+      verify(refreshTokenService).refreshTokens(refreshToken);
+    }
+
+    @Test
+    @DisplayName("should return login response in body")
+    void should_return_login_response() {
+      // given
+      var refreshTokenData = new RefreshTokenData(
+          "dummy",
+          List.of(ROLE_USER.getDisplayName()),
+          "eyAccessToken",
+          ResponseCookie.from("foo", "bar").build()
+      );
+      doReturn(refreshTokenData).when(refreshTokenService).refreshTokens(any());
+
+      // when
+      var response = restAssuredUtils.doGetWithCookies(Map.of("refresh_token", "eyFoo"));
+
+      // then
+      var extractedResponse = response.extract().as(LoginResponse.class);
+      assertThat(extractedResponse).isEqualTo(new LoginResponse("dummy", List.of("User"), "eyAccessToken"));
+    }
+
+    @Test
+    @DisplayName("should return response with cookie header")
+    void should_return_response_with_cookie_header() {
+      // given
+      var refreshTokenData = new RefreshTokenData(
+          "dummy",
+          List.of(ROLE_USER.getDisplayName()),
+          "eyAccessToken",
+          ResponseCookie.from("refresh_token", "eyRefreshToken").build()
+      );
+      doReturn(refreshTokenData).when(refreshTokenService).refreshTokens(any());
+
+      // when
+      var headers = restAssuredUtils.doGetWithCookiesReturningHeaders(Map.of("refresh_token", "eyFoo"));
+
+      // then
+      assertThat(headers).contains(new Header(SET_COOKIE, "refresh_token=eyRefreshToken"));
+    }
+  }
+}


### PR DESCRIPTION
Currently, when testing the local frontend with the preview backend, there are problems with the persistent login. Specifically, you have to login again every time you refresh the page, because localhost does not receive cookies from "remote" systems (refresh token is sent in cookie). 

For this reason I built a kind of mock mode. With the property `security.mock-mode` enabled, this is de-facto an auto-login for the user 'Administrator'.