### PR TITLE
use commit hashed instead of version tag for github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,9 @@ jobs:
       issues: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # 4.2.0
       - name: Set up JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@b36c23c0d998641eff861008f374ee103c25ac73 # 4.4.0
         with:
           distribution: 'temurin'
           java-version: 17
@@ -26,6 +26,6 @@ jobs:
         run: ./gradlew clean build --no-daemon --info --stacktrace
       - name: Publish Test Report
         if: ${{ always() }}
-        uses: scacap/action-surefire-report@v1
+        uses: scacap/action-surefire-report@a2911bd1a4412ec18dde2d93b1758b3e56d2a880 # 1.8.0
         with:
           report_paths: '**/build/test-results/test/TEST-*.xml'

--- a/.github/workflows/compile-frontend.yml
+++ b/.github/workflows/compile-frontend.yml
@@ -13,9 +13,9 @@ jobs:
       matrix:
         node-version: [20.x]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # 4.2.0
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@0a44ba7841725637a19e28fa30b79a866c81b0a6 # 4.0.4
         with:
           node-version: ${{ matrix.node-version }}
       - run: |

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -11,17 +11,17 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout master
-        uses: actions/checkout@v4
+        uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # 4.2.0
 
       - name: Set up JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@b36c23c0d998641eff861008f374ee103c25ac73 # 4.4.0
         with:
           distribution: 'temurin'
           java-version: 17
           cache: 'gradle'
 
       - name: Login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # 3.3.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}

--- a/.github/workflows/lint-frontend.yml
+++ b/.github/workflows/lint-frontend.yml
@@ -9,10 +9,10 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # 4.2.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@0a44ba7841725637a19e28fa30b79a866c81b0a6 # 4.0.4
         with:
           node-version: 20
 

--- a/.github/workflows/update-gradle-wrapper.yml
+++ b/.github/workflows/update-gradle-wrapper.yml
@@ -9,17 +9,17 @@ jobs:
   update-gradle-wrapper:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # 4.2.0
       - name: Set up JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@b36c23c0d998641eff861008f374ee103c25ac73 # 4.4.0
         with:
           distribution: 'temurin'
           java-version: 17
           cache: 'gradle'
       - name: Update Gradle Wrapper
-        uses: gradle-update/update-gradle-wrapper-action@v2
+        uses: gradle-update/update-gradle-wrapper-action@9268373d69bd0974b6318eb3b512b8e025060bbe # 2.0.0
         with:
           repo-token: ${{ secrets.ACTION_TOKEN }}
           labels: dependencies
           reviewers: hedgehog1833, DanielW1987
-      - uses: gradle/wrapper-validation-action@v3
+      - uses: gradle/actions/wrapper-validation@d156388eb19639ec20ade50009f3d199ce1e2808 # 4.1.0


### PR DESCRIPTION
The version tags are mutable. To mitigate supply chain attacks we now pin our actions to certain version commit hashed, which are not mutable. Dependabot also gets this and even adjusts the comment with the actual version.